### PR TITLE
ログイン画面を作成する

### DIFF
--- a/FoodTracker.xcodeproj/project.pbxproj
+++ b/FoodTracker.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		89878BAB1B842B41004CCD77 /* Micropost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89878BAA1B842B41004CCD77 /* Micropost.swift */; };
 		89878BAC1B842B41004CCD77 /* Micropost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89878BAA1B842B41004CCD77 /* Micropost.swift */; };
 		89878BB21B844E8C004CCD77 /* FeedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89878BB11B844E8C004CCD77 /* FeedViewController.swift */; };
+		89A0FFF21B8D7BB000652A4B /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89A0FFF11B8D7BB000652A4B /* LoginViewController.swift */; };
 		AB55C03A1B8304830077C16C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB55C0391B8304830077C16C /* AppDelegate.swift */; };
 		AB55C0411B8304830077C16C /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AB55C0401B8304830077C16C /* Images.xcassets */; };
 		AB55C0501B8304830077C16C /* FoodTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB55C04F1B8304830077C16C /* FoodTrackerTests.swift */; };
@@ -41,6 +42,7 @@
 		6B82560B1B8AE79D005E2397 /* UserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserTests.swift; path = FoodTrackerTests/UserTests.swift; sourceTree = SOURCE_ROOT; };
 		89878BAA1B842B41004CCD77 /* Micropost.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Micropost.swift; path = Classes/Models/Micropost.swift; sourceTree = "<group>"; };
 		89878BB11B844E8C004CCD77 /* FeedViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FeedViewController.swift; path = Classes/Controllers/FeedViewController.swift; sourceTree = "<group>"; };
+		89A0FFF11B8D7BB000652A4B /* LoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LoginViewController.swift; path = Classes/Controllers/LoginViewController.swift; sourceTree = "<group>"; };
 		AB55C0341B8304830077C16C /* FoodTracker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FoodTracker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB55C0381B8304830077C16C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AB55C0391B8304830077C16C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -90,6 +92,7 @@
 				89878BB11B844E8C004CCD77 /* FeedViewController.swift */,
 				AB785DDD1B846EED002DA142 /* MicropostlViewController.swift */,
 				6B8256001B8ACB8D005E2397 /* UserViewController.swift */,
+				89A0FFF11B8D7BB000652A4B /* LoginViewController.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -291,6 +294,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				89A0FFF21B8D7BB000652A4B /* LoginViewController.swift in Sources */,
 				ABF1C7311B84557D00032F37 /* MicropostTableViewCell.swift in Sources */,
 				6B8256011B8ACB8D005E2397 /* UserViewController.swift in Sources */,
 				89878BB21B844E8C004CCD77 /* FeedViewController.swift in Sources */,

--- a/FoodTracker/Classes/Controllers/LoginViewController.swift
+++ b/FoodTracker/Classes/Controllers/LoginViewController.swift
@@ -6,6 +6,7 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
     @IBOutlet weak var passwordField: UITextField!
     @IBOutlet weak var loginButton: UIButton!
 
+    // MARK: - View Events
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/FoodTracker/Classes/Controllers/LoginViewController.swift
+++ b/FoodTracker/Classes/Controllers/LoginViewController.swift
@@ -33,6 +33,15 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
     func checkValidLoginForm() {
         let email = emailField.text ?? ""
         let password = passwordField.text ?? ""
-        loginButton.enabled = !email.isEmpty && !password.isEmpty
+        loginButton.enabled = checkPresenceField(email, password: password) && checkValidEmail(email)
+    }
+    
+    func checkValidEmail(email: String) -> Bool{
+        let regex = "^[\\w+\\-.]+@[a-z\\d\\-]+(\\.[a-z\\d\\-]+)*\\.[a-z]+$"
+        return NSPredicate(format: "SELF MATCHES %@", regex).evaluateWithObject(email)
+    }
+    
+    func checkPresenceField(email: String, password: String) -> Bool{
+        return !email.isEmpty && !password.isEmpty
     }
 }

--- a/FoodTracker/Classes/Controllers/LoginViewController.swift
+++ b/FoodTracker/Classes/Controllers/LoginViewController.swift
@@ -1,0 +1,14 @@
+import UIKit
+
+class LoginViewController: UIViewController {
+    // MARK: - Properties
+    @IBOutlet weak var emailField: UITextField!
+    @IBOutlet weak var passwordField: UITextField!
+    @IBOutlet weak var loginButton: UIButton!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+
+}

--- a/FoodTracker/Classes/Controllers/LoginViewController.swift
+++ b/FoodTracker/Classes/Controllers/LoginViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class LoginViewController: UIViewController {
+class LoginViewController: UIViewController, UITextFieldDelegate {
     // MARK: - Properties
     @IBOutlet weak var emailField: UITextField!
     @IBOutlet weak var passwordField: UITextField!
@@ -8,7 +8,12 @@ class LoginViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        emailField.delegate = self
+        passwordField.delegate = self
     }
-
-
+    
+    func textFieldShouldReturn(textField: UITextField) -> Bool{
+        view.endEditing(true)
+        return false
+    }
 }

--- a/FoodTracker/Classes/Controllers/LoginViewController.swift
+++ b/FoodTracker/Classes/Controllers/LoginViewController.swift
@@ -8,12 +8,31 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
         emailField.delegate = self
         passwordField.delegate = self
+        
+        checkValidLoginForm()
     }
     
+    // MARK: - UITextFieldDelegate
     func textFieldShouldReturn(textField: UITextField) -> Bool{
         view.endEditing(true)
         return false
+    }
+    
+    func textFieldDidBeginEditing(textField: UITextField) {
+        loginButton.enabled = false
+    }
+    
+    func textFieldShouldEndEditing(textField: UITextField) -> Bool{
+        checkValidLoginForm()
+        return true
+    }
+    
+    func checkValidLoginForm() {
+        let email = emailField.text ?? ""
+        let password = passwordField.text ?? ""
+        loginButton.enabled = !email.isEmpty && !password.isEmpty
     }
 }

--- a/FoodTracker/Classes/Storyboards/Main.storyboard
+++ b/FoodTracker/Classes/Storyboards/Main.storyboard
@@ -288,7 +288,7 @@ App</string>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HIB-iO-WOq">
                                 <rect key="frame" x="0.0" y="-30" width="97" height="30"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
+                                <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GBj-fX-bsr">
                                 <rect key="frame" x="-23" y="-15" width="46" height="30"/>

--- a/FoodTracker/Classes/Storyboards/Main.storyboard
+++ b/FoodTracker/Classes/Storyboards/Main.storyboard
@@ -274,6 +274,9 @@ App</string>
                                 <state key="normal" title="Log in">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <segue destination="NxN-W1-faf" kind="show" id="7f1-2I-NY9"/>
+                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3D3-6o-Yb6">
                                 <rect key="frame" x="-23" y="-15" width="46" height="30"/>

--- a/FoodTracker/Classes/Storyboards/Main.storyboard
+++ b/FoodTracker/Classes/Storyboards/Main.storyboard
@@ -285,7 +285,7 @@ App</string>
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                             </button>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HIB-iO-WOq">
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" clearsOnBeginEditing="YES" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="HIB-iO-WOq">
                                 <rect key="frame" x="0.0" y="-30" width="97" height="30"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
@@ -296,7 +296,7 @@ App</string>
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                             </button>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Email" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="JCQ-IN-0lf">
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Email" clearsOnBeginEditing="YES" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="JCQ-IN-0lf">
                                 <rect key="frame" x="0.0" y="-30" width="97" height="30"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>

--- a/FoodTracker/Classes/Storyboards/Main.storyboard
+++ b/FoodTracker/Classes/Storyboards/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="NxN-W1-faf">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="KDD-nb-63e">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
         <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
@@ -242,6 +242,193 @@
             </objects>
             <point key="canvasLocation" x="-603" y="388"/>
         </scene>
+        <!--View Controller-->
+        <scene sceneID="MLw-rH-x4A">
+            <objects>
+                <viewController id="KDD-nb-63e" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="j4B-Gq-Oix"/>
+                        <viewControllerLayoutGuide type="bottom" id="s9q-U1-ifr"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="4Al-GK-8en">
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ceL-jg-YvQ">
+                                <rect key="frame" x="0.0" y="-21" width="42" height="21"/>
+                                <string key="text">Sample
+App</string>
+                                <fontDescription key="fontDescription" type="system" pointSize="39"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                                <variation key="widthClass=compact" misplaced="YES">
+                                    <rect key="frame" x="95" y="115" width="210" height="59"/>
+                                </variation>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hZV-py-OPX">
+                                <rect key="frame" x="-23" y="-15" width="46" height="30"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                <state key="normal" title="Log in">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <variation key="widthClass=compact" misplaced="YES">
+                                    <rect key="frame" x="95" y="450" width="210" height="49"/>
+                                </variation>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3D3-6o-Yb6">
+                                <rect key="frame" x="-23" y="-15" width="46" height="30"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                <state key="normal" title="Sign up">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <variation key="widthClass=compact" misplaced="YES">
+                                    <rect key="frame" x="95" y="498" width="210" height="52"/>
+                                </variation>
+                            </button>
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Email" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="JCQ-IN-0lf">
+                                <rect key="frame" x="0.0" y="-30" width="97" height="30"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                                <variation key="widthClass=compact" misplaced="YES">
+                                    <rect key="frame" x="80" y="302" width="240" height="30"/>
+                                </variation>
+                            </textField>
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HIB-iO-WOq">
+                                <rect key="frame" x="0.0" y="-30" width="97" height="30"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                                <variation key="widthClass=compact" misplaced="YES">
+                                    <rect key="frame" x="80" y="375" width="240" height="30"/>
+                                </variation>
+                            </textField>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GBj-fX-bsr">
+                                <rect key="frame" x="-23" y="-15" width="46" height="30"/>
+                                <state key="normal" title=" Forgot">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <variation key="widthClass=compact" misplaced="YES">
+                                    <rect key="frame" x="271" y="413" width="49" height="30"/>
+                                </variation>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="App" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oHM-DA-Up4">
+                                <rect key="frame" x="0.0" y="-21" width="42" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="38"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                                <variation key="widthClass=compact" misplaced="YES">
+                                    <rect key="frame" x="95" y="173" width="210" height="59"/>
+                                </variation>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="GBj-fX-bsr" firstAttribute="top" secondItem="HIB-iO-WOq" secondAttribute="bottom" constant="8" id="2ug-cT-bMr"/>
+                            <constraint firstItem="3D3-6o-Yb6" firstAttribute="leading" secondItem="4Al-GK-8en" secondAttribute="leadingMargin" constant="79" id="3GH-8a-QsO"/>
+                            <constraint firstItem="oHM-DA-Up4" firstAttribute="top" secondItem="j4B-Gq-Oix" secondAttribute="bottom" constant="153" id="71z-cp-sGW"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="3D3-6o-Yb6" secondAttribute="trailing" constant="79" id="7SH-HB-d5w"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="hZV-py-OPX" secondAttribute="trailing" constant="79" id="AMO-uR-plr"/>
+                            <constraint firstItem="hZV-py-OPX" firstAttribute="leading" secondItem="4Al-GK-8en" secondAttribute="leadingMargin" constant="79" id="BVw-b0-6Po"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="GBj-fX-bsr" secondAttribute="trailing" constant="64" id="GPq-rm-8GB"/>
+                            <constraint firstAttribute="centerX" secondItem="JCQ-IN-0lf" secondAttribute="centerX" id="NGx-cI-C1z"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="HIB-iO-WOq" secondAttribute="trailing" constant="64" id="RK6-Wo-GyG"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="JCQ-IN-0lf" secondAttribute="trailing" constant="64" id="SNL-Hn-IYY"/>
+                            <constraint firstAttribute="centerX" secondItem="oHM-DA-Up4" secondAttribute="centerX" id="SdV-3M-KEo"/>
+                            <constraint firstItem="s9q-U1-ifr" firstAttribute="top" secondItem="3D3-6o-Yb6" secondAttribute="bottom" constant="50" id="UY2-Gq-KTg"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="ceL-jg-YvQ" secondAttribute="trailing" constant="79" id="UyD-X2-gCu"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="oHM-DA-Up4" secondAttribute="trailing" constant="79" id="Wh9-Br-lZT"/>
+                            <constraint firstItem="HIB-iO-WOq" firstAttribute="leading" secondItem="4Al-GK-8en" secondAttribute="leadingMargin" constant="64" id="cYZ-yZ-XSg"/>
+                            <constraint firstAttribute="centerX" secondItem="HIB-iO-WOq" secondAttribute="centerX" id="evs-Q9-zpc"/>
+                            <constraint firstItem="JCQ-IN-0lf" firstAttribute="top" secondItem="oHM-DA-Up4" secondAttribute="bottom" constant="70" id="jUA-V7-fbc"/>
+                            <constraint firstItem="JCQ-IN-0lf" firstAttribute="leading" secondItem="4Al-GK-8en" secondAttribute="leadingMargin" constant="64" id="khc-Y7-qiN"/>
+                            <constraint firstItem="s9q-U1-ifr" firstAttribute="top" secondItem="hZV-py-OPX" secondAttribute="bottom" constant="101" id="qV2-Fg-gld"/>
+                            <constraint firstItem="ceL-jg-YvQ" firstAttribute="top" secondItem="j4B-Gq-Oix" secondAttribute="bottom" constant="95" id="qw2-Fs-Xgl"/>
+                            <constraint firstItem="HIB-iO-WOq" firstAttribute="top" secondItem="JCQ-IN-0lf" secondAttribute="bottom" constant="43" id="sFO-Am-OMY"/>
+                            <constraint firstAttribute="centerX" secondItem="ceL-jg-YvQ" secondAttribute="centerX" id="sfV-ZK-Agx"/>
+                            <constraint firstItem="ceL-jg-YvQ" firstAttribute="leading" secondItem="4Al-GK-8en" secondAttribute="leadingMargin" constant="79" id="tGJ-0P-eSm"/>
+                            <constraint firstItem="oHM-DA-Up4" firstAttribute="leading" secondItem="4Al-GK-8en" secondAttribute="leadingMargin" constant="79" id="tvU-Km-sgN"/>
+                            <constraint firstAttribute="centerX" secondItem="hZV-py-OPX" secondAttribute="centerX" id="zx4-6S-mh5"/>
+                        </constraints>
+                        <variation key="default">
+                            <mask key="subviews">
+                                <exclude reference="ceL-jg-YvQ"/>
+                                <exclude reference="hZV-py-OPX"/>
+                                <exclude reference="3D3-6o-Yb6"/>
+                                <exclude reference="JCQ-IN-0lf"/>
+                                <exclude reference="HIB-iO-WOq"/>
+                                <exclude reference="GBj-fX-bsr"/>
+                                <exclude reference="oHM-DA-Up4"/>
+                            </mask>
+                            <mask key="constraints">
+                                <exclude reference="UyD-X2-gCu"/>
+                                <exclude reference="qw2-Fs-Xgl"/>
+                                <exclude reference="sfV-ZK-Agx"/>
+                                <exclude reference="tGJ-0P-eSm"/>
+                                <exclude reference="71z-cp-sGW"/>
+                                <exclude reference="SdV-3M-KEo"/>
+                                <exclude reference="Wh9-Br-lZT"/>
+                                <exclude reference="tvU-Km-sgN"/>
+                                <exclude reference="NGx-cI-C1z"/>
+                                <exclude reference="SNL-Hn-IYY"/>
+                                <exclude reference="jUA-V7-fbc"/>
+                                <exclude reference="khc-Y7-qiN"/>
+                                <exclude reference="RK6-Wo-GyG"/>
+                                <exclude reference="cYZ-yZ-XSg"/>
+                                <exclude reference="evs-Q9-zpc"/>
+                                <exclude reference="sFO-Am-OMY"/>
+                                <exclude reference="AMO-uR-plr"/>
+                                <exclude reference="BVw-b0-6Po"/>
+                                <exclude reference="zx4-6S-mh5"/>
+                                <exclude reference="2ug-cT-bMr"/>
+                                <exclude reference="GPq-rm-8GB"/>
+                                <exclude reference="3GH-8a-QsO"/>
+                                <exclude reference="7SH-HB-d5w"/>
+                                <exclude reference="UY2-Gq-KTg"/>
+                                <exclude reference="qV2-Fg-gld"/>
+                            </mask>
+                        </variation>
+                        <variation key="widthClass=compact">
+                            <mask key="subviews">
+                                <include reference="ceL-jg-YvQ"/>
+                                <include reference="hZV-py-OPX"/>
+                                <include reference="3D3-6o-Yb6"/>
+                                <include reference="JCQ-IN-0lf"/>
+                                <include reference="HIB-iO-WOq"/>
+                                <include reference="GBj-fX-bsr"/>
+                                <include reference="oHM-DA-Up4"/>
+                            </mask>
+                            <mask key="constraints">
+                                <include reference="UyD-X2-gCu"/>
+                                <include reference="qw2-Fs-Xgl"/>
+                                <include reference="sfV-ZK-Agx"/>
+                                <include reference="tGJ-0P-eSm"/>
+                                <include reference="71z-cp-sGW"/>
+                                <include reference="SdV-3M-KEo"/>
+                                <include reference="Wh9-Br-lZT"/>
+                                <include reference="tvU-Km-sgN"/>
+                                <include reference="NGx-cI-C1z"/>
+                                <include reference="SNL-Hn-IYY"/>
+                                <include reference="jUA-V7-fbc"/>
+                                <include reference="khc-Y7-qiN"/>
+                                <include reference="RK6-Wo-GyG"/>
+                                <include reference="cYZ-yZ-XSg"/>
+                                <include reference="evs-Q9-zpc"/>
+                                <include reference="sFO-Am-OMY"/>
+                                <include reference="AMO-uR-plr"/>
+                                <include reference="BVw-b0-6Po"/>
+                                <include reference="zx4-6S-mh5"/>
+                                <include reference="2ug-cT-bMr"/>
+                                <include reference="GPq-rm-8GB"/>
+                                <include reference="3GH-8a-QsO"/>
+                                <include reference="7SH-HB-d5w"/>
+                                <include reference="UY2-Gq-KTg"/>
+                                <include reference="qV2-Fg-gld"/>
+                            </mask>
+                        </variation>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Cab-nt-mlF" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1308" y="388"/>
+        </scene>
         <!--Config-->
         <scene sceneID="5WQ-np-3DR">
             <objects>
@@ -249,7 +436,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="Cg0-FZ-A2R">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <color key="backgroundColor" red="0.93725490196078431" green="0.93725490196078431" blue="0.95686274509803926" alpha="1" colorSpace="calibratedRGB"/>
                         <sections>
                             <tableViewSection id="mdG-2S-HrB">
                                 <cells>
@@ -261,7 +448,7 @@
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="All" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="GjA-sy-8l1">
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                     <variation key="widthClass=compact">
                                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
@@ -281,7 +468,7 @@
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Follwers" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="R8C-lK-BHY">
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                     <variation key="widthClass=compact">
                                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
@@ -298,7 +485,7 @@
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Following" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="b5V-Xf-s56">
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                     <variation key="widthClass=compact">
                                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
@@ -319,7 +506,7 @@
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Profile edit" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="D63-nr-KzM">
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                     <variation key="widthClass=compact">
                                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
@@ -361,7 +548,7 @@
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="user name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p2h-WL-bd7">
                                             <rect key="frame" x="0.0" y="-21" width="42" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="contactAdd" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yre-4t-S5p">
@@ -495,7 +682,7 @@
                                             <constraint firstAttribute="height" constant="20.5" id="bkH-qp-a7J"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                         <variation key="default">
                                             <mask key="constraints">
@@ -547,7 +734,7 @@
                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="21" id="tqJ-XV-ft9"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                                 <variation key="default">
                                                     <mask key="constraints">
@@ -570,7 +757,7 @@
                                                     <constraint firstAttribute="height" constant="21" id="uft-Ze-NKt"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                                 <variation key="default">
                                                     <mask key="constraints">
@@ -589,7 +776,7 @@
                                                     <constraint firstAttribute="height" constant="21" id="tLV-wm-8VO"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                                 <variation key="default">
                                                     <mask key="constraints">

--- a/FoodTracker/Classes/Storyboards/Main.storyboard
+++ b/FoodTracker/Classes/Storyboards/Main.storyboard
@@ -296,10 +296,10 @@ App</string>
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                             </button>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Email" clearsOnBeginEditing="YES" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="JCQ-IN-0lf">
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Email" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="JCQ-IN-0lf">
                                 <rect key="frame" x="0.0" y="-30" width="97" height="30"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
+                                <textInputTraits key="textInputTraits" keyboardType="emailAddress"/>
                             </textField>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>

--- a/FoodTracker/Classes/Storyboards/Main.storyboard
+++ b/FoodTracker/Classes/Storyboards/Main.storyboard
@@ -242,15 +242,16 @@
             </objects>
             <point key="canvasLocation" x="-603" y="388"/>
         </scene>
-        <!--View Controller-->
+        <!--Login View Controller-->
         <scene sceneID="MLw-rH-x4A">
             <objects>
-                <viewController id="KDD-nb-63e" sceneMemberID="viewController">
+                <viewController id="KDD-nb-63e" customClass="LoginViewController" customModule="FoodTracker" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="j4B-Gq-Oix"/>
                         <viewControllerLayoutGuide type="bottom" id="s9q-U1-ifr"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="4Al-GK-8en">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ceL-jg-YvQ">
@@ -260,9 +261,12 @@ App</string>
                                 <fontDescription key="fontDescription" type="system" pointSize="39"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
-                                <variation key="widthClass=compact" misplaced="YES">
-                                    <rect key="frame" x="95" y="115" width="210" height="59"/>
-                                </variation>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="App" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oHM-DA-Up4">
+                                <rect key="frame" x="0.0" y="-21" width="42" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="38"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hZV-py-OPX">
                                 <rect key="frame" x="-23" y="-15" width="46" height="30"/>
@@ -270,9 +274,6 @@ App</string>
                                 <state key="normal" title="Log in">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
-                                <variation key="widthClass=compact" misplaced="YES">
-                                    <rect key="frame" x="95" y="450" width="210" height="49"/>
-                                </variation>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3D3-6o-Yb6">
                                 <rect key="frame" x="-23" y="-15" width="46" height="30"/>
@@ -280,44 +281,23 @@ App</string>
                                 <state key="normal" title="Sign up">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
-                                <variation key="widthClass=compact" misplaced="YES">
-                                    <rect key="frame" x="95" y="498" width="210" height="52"/>
-                                </variation>
                             </button>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Email" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="JCQ-IN-0lf">
-                                <rect key="frame" x="0.0" y="-30" width="97" height="30"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                                <variation key="widthClass=compact" misplaced="YES">
-                                    <rect key="frame" x="80" y="302" width="240" height="30"/>
-                                </variation>
-                            </textField>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HIB-iO-WOq">
                                 <rect key="frame" x="0.0" y="-30" width="97" height="30"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
-                                <variation key="widthClass=compact" misplaced="YES">
-                                    <rect key="frame" x="80" y="375" width="240" height="30"/>
-                                </variation>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GBj-fX-bsr">
                                 <rect key="frame" x="-23" y="-15" width="46" height="30"/>
                                 <state key="normal" title=" Forgot">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
-                                <variation key="widthClass=compact" misplaced="YES">
-                                    <rect key="frame" x="271" y="413" width="49" height="30"/>
-                                </variation>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="App" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oHM-DA-Up4">
-                                <rect key="frame" x="0.0" y="-21" width="42" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="38"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                <nil key="highlightedColor"/>
-                                <variation key="widthClass=compact" misplaced="YES">
-                                    <rect key="frame" x="95" y="173" width="210" height="59"/>
-                                </variation>
-                            </label>
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Email" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="JCQ-IN-0lf">
+                                <rect key="frame" x="0.0" y="-30" width="97" height="30"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
@@ -350,14 +330,22 @@ App</string>
                         <variation key="default">
                             <mask key="subviews">
                                 <exclude reference="ceL-jg-YvQ"/>
+                                <exclude reference="oHM-DA-Up4"/>
                                 <exclude reference="hZV-py-OPX"/>
                                 <exclude reference="3D3-6o-Yb6"/>
-                                <exclude reference="JCQ-IN-0lf"/>
                                 <exclude reference="HIB-iO-WOq"/>
                                 <exclude reference="GBj-fX-bsr"/>
-                                <exclude reference="oHM-DA-Up4"/>
+                                <exclude reference="JCQ-IN-0lf"/>
                             </mask>
                             <mask key="constraints">
+                                <exclude reference="RK6-Wo-GyG"/>
+                                <exclude reference="cYZ-yZ-XSg"/>
+                                <exclude reference="evs-Q9-zpc"/>
+                                <exclude reference="sFO-Am-OMY"/>
+                                <exclude reference="NGx-cI-C1z"/>
+                                <exclude reference="SNL-Hn-IYY"/>
+                                <exclude reference="jUA-V7-fbc"/>
+                                <exclude reference="khc-Y7-qiN"/>
                                 <exclude reference="UyD-X2-gCu"/>
                                 <exclude reference="qw2-Fs-Xgl"/>
                                 <exclude reference="sfV-ZK-Agx"/>
@@ -366,36 +354,36 @@ App</string>
                                 <exclude reference="SdV-3M-KEo"/>
                                 <exclude reference="Wh9-Br-lZT"/>
                                 <exclude reference="tvU-Km-sgN"/>
-                                <exclude reference="NGx-cI-C1z"/>
-                                <exclude reference="SNL-Hn-IYY"/>
-                                <exclude reference="jUA-V7-fbc"/>
-                                <exclude reference="khc-Y7-qiN"/>
-                                <exclude reference="RK6-Wo-GyG"/>
-                                <exclude reference="cYZ-yZ-XSg"/>
-                                <exclude reference="evs-Q9-zpc"/>
-                                <exclude reference="sFO-Am-OMY"/>
+                                <exclude reference="UY2-Gq-KTg"/>
+                                <exclude reference="qV2-Fg-gld"/>
+                                <exclude reference="3GH-8a-QsO"/>
+                                <exclude reference="7SH-HB-d5w"/>
+                                <exclude reference="2ug-cT-bMr"/>
+                                <exclude reference="GPq-rm-8GB"/>
                                 <exclude reference="AMO-uR-plr"/>
                                 <exclude reference="BVw-b0-6Po"/>
                                 <exclude reference="zx4-6S-mh5"/>
-                                <exclude reference="2ug-cT-bMr"/>
-                                <exclude reference="GPq-rm-8GB"/>
-                                <exclude reference="3GH-8a-QsO"/>
-                                <exclude reference="7SH-HB-d5w"/>
-                                <exclude reference="UY2-Gq-KTg"/>
-                                <exclude reference="qV2-Fg-gld"/>
                             </mask>
                         </variation>
                         <variation key="widthClass=compact">
                             <mask key="subviews">
                                 <include reference="ceL-jg-YvQ"/>
+                                <include reference="oHM-DA-Up4"/>
                                 <include reference="hZV-py-OPX"/>
                                 <include reference="3D3-6o-Yb6"/>
-                                <include reference="JCQ-IN-0lf"/>
                                 <include reference="HIB-iO-WOq"/>
                                 <include reference="GBj-fX-bsr"/>
-                                <include reference="oHM-DA-Up4"/>
+                                <include reference="JCQ-IN-0lf"/>
                             </mask>
                             <mask key="constraints">
+                                <include reference="RK6-Wo-GyG"/>
+                                <include reference="cYZ-yZ-XSg"/>
+                                <include reference="evs-Q9-zpc"/>
+                                <include reference="sFO-Am-OMY"/>
+                                <include reference="NGx-cI-C1z"/>
+                                <include reference="SNL-Hn-IYY"/>
+                                <include reference="jUA-V7-fbc"/>
+                                <include reference="khc-Y7-qiN"/>
                                 <include reference="UyD-X2-gCu"/>
                                 <include reference="qw2-Fs-Xgl"/>
                                 <include reference="sfV-ZK-Agx"/>
@@ -404,26 +392,23 @@ App</string>
                                 <include reference="SdV-3M-KEo"/>
                                 <include reference="Wh9-Br-lZT"/>
                                 <include reference="tvU-Km-sgN"/>
-                                <include reference="NGx-cI-C1z"/>
-                                <include reference="SNL-Hn-IYY"/>
-                                <include reference="jUA-V7-fbc"/>
-                                <include reference="khc-Y7-qiN"/>
-                                <include reference="RK6-Wo-GyG"/>
-                                <include reference="cYZ-yZ-XSg"/>
-                                <include reference="evs-Q9-zpc"/>
-                                <include reference="sFO-Am-OMY"/>
+                                <include reference="UY2-Gq-KTg"/>
+                                <include reference="qV2-Fg-gld"/>
+                                <include reference="3GH-8a-QsO"/>
+                                <include reference="7SH-HB-d5w"/>
+                                <include reference="2ug-cT-bMr"/>
+                                <include reference="GPq-rm-8GB"/>
                                 <include reference="AMO-uR-plr"/>
                                 <include reference="BVw-b0-6Po"/>
                                 <include reference="zx4-6S-mh5"/>
-                                <include reference="2ug-cT-bMr"/>
-                                <include reference="GPq-rm-8GB"/>
-                                <include reference="3GH-8a-QsO"/>
-                                <include reference="7SH-HB-d5w"/>
-                                <include reference="UY2-Gq-KTg"/>
-                                <include reference="qV2-Fg-gld"/>
                             </mask>
                         </variation>
                     </view>
+                    <connections>
+                        <outlet property="emailField" destination="JCQ-IN-0lf" id="P6y-B2-20H"/>
+                        <outlet property="loginButton" destination="hZV-py-OPX" id="umx-39-OaR"/>
+                        <outlet property="passwordField" destination="HIB-iO-WOq" id="tY2-68-1Ch"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Cab-nt-mlF" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>


### PR DESCRIPTION
@orzup @alotofwe cc @kuroyam 

下図のようなログイン画面を作成します。

<img width="152" alt="2015-08-26 11 20 33" src="https://cloud.githubusercontent.com/assets/2803040/9484270/119b3de4-4be5-11e5-9e0a-964f5d7318d7.png">
## merge条件
- [x] `nehan` がシュミュレータで動作確認をすること
  - [x] ログイン画面が表示できること
  - [x] email, passwordが入力できること
  - [x] emailは、バリデーションチェックが入っていること
  - [x] passwordは、入力した文字が隠れること
  - [x] email, passwordがともに空、またはemailが不正である場合はログインボタンが押せないこと
  - [x] ログインボタンを押して、ログイン画面からfeedへ遷移できること
