### PR TITLE
【保留】deploy時に毎回identityを設定しないようにする

### DIFF
--- a/FoodTracker.xcodeproj/project.pbxproj
+++ b/FoodTracker.xcodeproj/project.pbxproj
@@ -273,6 +273,7 @@
 				TargetAttributes = {
 					AB55C0331B8304830077C16C = {
 						CreatedOnToolsVersion = 6.4;
+						DevelopmentTeam = NH7E35TW7H;
 					};
 					AB55C0481B8304830077C16C = {
 						CreatedOnToolsVersion = 6.4;
@@ -495,6 +496,7 @@
 			baseConfigurationReference = 31D3F4020A52B9C72A4E00EE /* Pods.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = FoodTracker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -507,6 +509,7 @@
 			baseConfigurationReference = 0B37E5E41D741F08483B9CD0 /* Pods.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_FILE = FoodTracker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/FoodTracker/Info.plist
+++ b/FoodTracker/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>nehan.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>jp.co.paperboy.dev.railstutorial.nehan.$(PRODUCT_NAME:rfc1034identifier)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Identityをdeploy用設定に変更し，毎回手動で設定をしないようにしたいと思いました．
# Close条件

@takuminnnn or @orzup :ok: 
- [ ] このブランチでrunしてもシミュレータが起動しエラーが起こらない
