### PR TITLE
URLからアプリを起動する

### DIFF
--- a/FoodTracker/AppDelegate.swift
+++ b/FoodTracker/AppDelegate.swift
@@ -11,10 +11,10 @@ import Alamofire
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
+    
     var window: UIWindow?
-
-
+    
+    
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // avoid "The certificate for this server is invalid"
         let manager = Alamofire.Manager.sharedInstance
@@ -44,29 +44,61 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         return true
     }
-
+    
+    func application(application: UIApplication, openURL url: NSURL, sourceApplication: String?, annotation: AnyObject?) -> Bool {
+        self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
+        var storyboard = UIStoryboard(name: "Main", bundle: nil)
+        
+        if url.host != nil {
+            let identifier = getControllerIdentifierFromURL(url)
+            var initialViewController = storyboard.instantiateViewControllerWithIdentifier(identifier) as! UIViewController
+            self.window?.rootViewController = initialViewController
+            self.window?.makeKeyAndVisible()
+        }
+        
+        var params = Dictionary<String, String>()
+        if url.query != nil {
+            params = getParamsFromURL(url)
+        }
+        
+        return true
+    }
+    
     func applicationWillResignActive(application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
-
+    
     func applicationDidEnterBackground(application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
-
+    
     func applicationWillEnterForeground(application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
-
+    
     func applicationDidBecomeActive(application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
-
+    
     func applicationWillTerminate(application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
-
-
+    
+    func getControllerIdentifierFromURL(url: NSURL) -> String {
+        return url.host!.capitalizedString + "NavigationController"
+    }
+    
+    func getParamsFromURL(url: NSURL) -> Dictionary<String, String> {
+        var params = Dictionary<String, String>()
+        if let query = url.query as String! {
+            for param in split(query, allowEmptySlices: true, isSeparator: { $0 == "&" }) {
+                let elements = split(param, allowEmptySlices: true, isSeparator: { $0 == "=" })
+                params[elements[0]] = elements[1]
+            }
+        }
+        return params
+    }
 }
 

--- a/FoodTracker/AppDelegate.swift
+++ b/FoodTracker/AppDelegate.swift
@@ -46,10 +46,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func application(application: UIApplication, openURL url: NSURL, sourceApplication: String?, annotation: AnyObject?) -> Bool {
-        self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
-        var storyboard = UIStoryboard(name: "Main", bundle: nil)
         
         if url.host != nil {
+            self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
+            var storyboard = UIStoryboard(name: "Main", bundle: nil)
             let identifier = getControllerIdentifierFromURL(url)
             var initialViewController = storyboard.instantiateViewControllerWithIdentifier(identifier) as! UIViewController
             self.window?.rootViewController = initialViewController

--- a/FoodTracker/AppDelegate.swift
+++ b/FoodTracker/AppDelegate.swift
@@ -11,10 +11,10 @@ import Alamofire
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    
+
     var window: UIWindow?
-    
-    
+
+
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // avoid "The certificate for this server is invalid"
         let manager = Alamofire.Manager.sharedInstance
@@ -68,28 +68,28 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
-    
+
     func applicationDidEnterBackground(application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
-    
+
     func applicationWillEnterForeground(application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
-    
+
     func applicationDidBecomeActive(application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
-    
+
     func applicationWillTerminate(application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
-    
+
     func getControllerIdentifierFromURL(url: NSURL) -> String {
         return url.host!.capitalizedString + "NavigationController"
     }
-    
+
     func getParamsFromURL(url: NSURL) -> Dictionary<String, String> {
         var params = Dictionary<String, String>()
         if let query = url.query as String! {

--- a/FoodTracker/Classes/Controllers/SignupViewController.swift
+++ b/FoodTracker/Classes/Controllers/SignupViewController.swift
@@ -68,7 +68,8 @@ class SignupViewController: UIViewController, UITextFieldDelegate {
             "password_confirmation": password_confirmation
         ]
         SVProgressHUD.showWithMaskType(SVProgressHUDMaskType.Black)
-        Alamofire.request(.POST, "https://157.7.190.148/api/users", parameters: params, encoding: .JSON)
+        //Alamofire.request(.POST, "https://157.7.190.148/api/users", parameters: params, encoding: .JSON)
+        Alamofire.request(.POST, "http://localhost:3000/api/users", parameters: params, encoding: .JSON)
             .responseJSON { (request, response, JSON, error) in
                 println(JSON)
                 var json = JSON as! Dictionary<String, AnyObject>

--- a/FoodTracker/Classes/Controllers/SignupViewController.swift
+++ b/FoodTracker/Classes/Controllers/SignupViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import Alamofire
 import SVProgressHUD
+import SwiftyJSON
 
 class SignupViewController: UIViewController, UITextFieldDelegate {
     // MARK: - Properties
@@ -69,16 +70,17 @@ class SignupViewController: UIViewController, UITextFieldDelegate {
         ]
         SVProgressHUD.showWithMaskType(SVProgressHUDMaskType.Black)
         Alamofire.request(Router.PostUser(params: params)).responseJSON { (request, response, data, error) -> Void in
-            println(data)
-            var json = data as! Dictionary<String, AnyObject>
-            if json["status"] as! Int == 200 {
+            let json = JSON(data!)
+            println(json)
+            println(json["status"])
+            if json["status"] == 200 {
                 SVProgressHUD.dismiss()
                 let targetViewController = self.storyboard!.instantiateViewControllerWithIdentifier("FeedNavigationController") as! UIViewController
                 self.presentViewController( targetViewController, animated: true, completion: nil)
             } else{
-                var messages = json["messages"] as! Dictionary<String, AnyObject>
-                var user_errors = messages["user"] as! Dictionary<String, String>
-                SVProgressHUD.showErrorWithStatus(user_errors.values.first)
+                var messages = json["messages"]
+                var user_errors = messages["user"]
+                SVProgressHUD.showErrorWithStatus(user_errors.dictionary!.values.first?.stringValue)
             }
         }
     }

--- a/FoodTracker/Classes/Controllers/SignupViewController.swift
+++ b/FoodTracker/Classes/Controllers/SignupViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Alamofire
 import SVProgressHUD
-       
+
 class SignupViewController: UIViewController, UITextFieldDelegate {
     // MARK: - Properties
     @IBOutlet var textFields: [UITextField]!
@@ -68,20 +68,18 @@ class SignupViewController: UIViewController, UITextFieldDelegate {
             "password_confirmation": password_confirmation
         ]
         SVProgressHUD.showWithMaskType(SVProgressHUDMaskType.Black)
-        //Alamofire.request(.POST, "https://157.7.190.148/api/users", parameters: params, encoding: .JSON)
-        Alamofire.request(.POST, "http://localhost:3000/api/users", parameters: params, encoding: .JSON)
-            .responseJSON { (request, response, JSON, error) in
-                println(JSON)
-                var json = JSON as! Dictionary<String, AnyObject>
-                if json["status"] as! Int == 200 {
-                    SVProgressHUD.dismiss()
-                    let targetViewController = self.storyboard!.instantiateViewControllerWithIdentifier("FeedNavigationController") as! UIViewController
-                    self.presentViewController( targetViewController, animated: true, completion: nil)
-                } else{
-                    var messages = json["messages"] as! Dictionary<String, AnyObject>
-                    var user_errors = messages["user"] as! Dictionary<String, String>
-                    SVProgressHUD.showErrorWithStatus(user_errors.values.first)
-                }
+        Alamofire.request(Router.PostUser(params: params)).responseJSON { (request, response, data, error) -> Void in
+            println(data)
+            var json = data as! Dictionary<String, AnyObject>
+            if json["status"] as! Int == 200 {
+                SVProgressHUD.dismiss()
+                let targetViewController = self.storyboard!.instantiateViewControllerWithIdentifier("FeedNavigationController") as! UIViewController
+                self.presentViewController( targetViewController, animated: true, completion: nil)
+            } else{
+                var messages = json["messages"] as! Dictionary<String, AnyObject>
+                var user_errors = messages["user"] as! Dictionary<String, String>
+                SVProgressHUD.showErrorWithStatus(user_errors.values.first)
+            }
         }
     }
 }

--- a/FoodTracker/Classes/Controllers/SignupViewController.swift
+++ b/FoodTracker/Classes/Controllers/SignupViewController.swift
@@ -78,9 +78,8 @@ class SignupViewController: UIViewController, UITextFieldDelegate {
                 let targetViewController = self.storyboard!.instantiateViewControllerWithIdentifier("FeedNavigationController") as! UIViewController
                 self.presentViewController( targetViewController, animated: true, completion: nil)
             } else{
-                var messages = json["messages"]
-                var user_errors = messages["user"]
-                SVProgressHUD.showErrorWithStatus(user_errors.dictionary!.values.first?.stringValue)
+                let tmp = json["messages"]["user"]
+                SVProgressHUD.showErrorWithStatus(json["messages"]["user"].dictionary!.values.first?.stringValue)
             }
         }
     }

--- a/FoodTracker/Classes/Models/Router.swift
+++ b/FoodTracker/Classes/Models/Router.swift
@@ -5,13 +5,15 @@ enum Router: URLRequestConvertible {
     
     case GetFeed(userId: Int)
     case GetAllUsers()
+    case PostUser(params: Dictionary<String, String>)
     
     var URLRequest: NSURLRequest {
         let (method: Alamofire.Method, path: String, parameters: [String: AnyObject]?) = {
             switch self {
             case .GetFeed(let userId): return (.GET, "/api/users/\(userId)/feed", nil)
             case .GetAllUsers(): return (.GET, "/api/users/", nil)
-            }
+            case .PostUser(let params): return (.POST, "/api/users", ["parameters": params])
+           }
             }()
         
         let URL = NSURL(string: Router.baseURLString)!

--- a/FoodTracker/Classes/Models/Router.swift
+++ b/FoodTracker/Classes/Models/Router.swift
@@ -7,19 +7,34 @@ enum Router: URLRequestConvertible {
     case GetAllUsers()
     case PostUser(params: Dictionary<String, String>)
     
+    var method: Alamofire.Method {
+        switch self {
+        case .GetFeed: return .GET
+        case .GetAllUsers: return .GET
+        case .PostUser: return .POST
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .GetFeed(let userId): return "/api/users/\(userId)/feed"
+        case .GetAllUsers: return "/api/users"
+        case .PostUser: return "/api/users"
+        }
+    }
+    
+    // MARK: URLRequestConvertible
+    
     var URLRequest: NSURLRequest {
-        let (method: Alamofire.Method, path: String, parameters: [String: AnyObject]?) = {
-            switch self {
-            case .GetFeed(let userId): return (.GET, "/api/users/\(userId)/feed", nil)
-            case .GetAllUsers(): return (.GET, "/api/users/", nil)
-            case .PostUser(let params): return (.POST, "/api/users", ["parameters": params])
-           }
-            }()
-        
         let URL = NSURL(string: Router.baseURLString)!
-        let URLRequest = NSURLRequest(URL: URL.URLByAppendingPathComponent(path))
-        let encoding = Alamofire.ParameterEncoding.URL
+        let mutableURLRequest = NSMutableURLRequest(URL: URL.URLByAppendingPathComponent(path))
+        mutableURLRequest.HTTPMethod = method.rawValue
         
-        return encoding.encode(URLRequest, parameters: parameters).0
+        switch self {
+        case .PostUser(let parameters):
+            return Alamofire.ParameterEncoding.JSON.encode(mutableURLRequest, parameters: parameters).0
+        default:
+            return mutableURLRequest
+        }
     }
 }

--- a/FoodTracker/Info.plist
+++ b/FoodTracker/Info.plist
@@ -27,7 +27,7 @@
 			<string>nehan.FoodTracker</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>kakiko</string>
+				<string>kakico</string>
 			</array>
 		</dict>
 	</array>

--- a/FoodTracker/Info.plist
+++ b/FoodTracker/Info.plist
@@ -18,6 +18,19 @@
 	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>nehan.FoodTracker</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakiko</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
各NavigationControllerに，StoryBoardからidentifierをつけることで移動可能です．

identifierの命名規則は"HogeNavigationCongroller"で
例えば，feedはFeedNavigationControllerにしています．

URLでは，hogeの部分をhostに指定します．
例えば，feedはkakico://feedになります．

&key=valueで，URLからAppDelegateに値を渡せるようになっています．
(今はなににも使っていませんが，これでauth_tokenを渡す予定です．
