### PR TITLE
パスワードリセットの表示場所を修正

### DIFF
--- a/FoodTracker.xcodeproj/project.pbxproj
+++ b/FoodTracker.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		6B82560A1B8AE755005E2397 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8256081B8AE754005E2397 /* User.swift */; };
 		6B82560C1B8AE79D005E2397 /* UserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B82560B1B8AE79D005E2397 /* UserTests.swift */; };
 		6BEBBBEA1B8EED81007EEF4A /* SignupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEBBBE91B8EED81007EEF4A /* SignupViewController.swift */; };
-		6BF845CB1B956BE700BDFA11 /* PasswordResetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF845CA1B956BE700BDFA11 /* PasswordResetViewController.swift */; };
+		6BF845CB1B956BE700BDFA11 /* ForgotPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF845CA1B956BE700BDFA11 /* ForgotPasswordViewController.swift */; };
 		8969712F1B93F5C500B0CB4C /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969712E1B93F5C500B0CB4C /* Router.swift */; };
 		89878BAB1B842B41004CCD77 /* Micropost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89878BAA1B842B41004CCD77 /* Micropost.swift */; };
 		89878BAC1B842B41004CCD77 /* Micropost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89878BAA1B842B41004CCD77 /* Micropost.swift */; };
@@ -48,7 +48,7 @@
 		6B8256081B8AE754005E2397 /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = User.swift; path = Classes/Models/User.swift; sourceTree = "<group>"; };
 		6B82560B1B8AE79D005E2397 /* UserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserTests.swift; path = FoodTrackerTests/UserTests.swift; sourceTree = SOURCE_ROOT; };
 		6BEBBBE91B8EED81007EEF4A /* SignupViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SignupViewController.swift; path = Classes/Controllers/SignupViewController.swift; sourceTree = "<group>"; };
-		6BF845CA1B956BE700BDFA11 /* PasswordResetViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PasswordResetViewController.swift; path = Classes/Controllers/PasswordResetViewController.swift; sourceTree = "<group>"; };
+		6BF845CA1B956BE700BDFA11 /* ForgotPasswordViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ForgotPasswordViewController.swift; path = Classes/Controllers/ForgotPasswordViewController.swift; sourceTree = "<group>"; };
 		8969712E1B93F5C500B0CB4C /* Router.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Router.swift; path = Classes/Models/Router.swift; sourceTree = "<group>"; };
 		89878BAA1B842B41004CCD77 /* Micropost.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Micropost.swift; path = Classes/Models/Micropost.swift; sourceTree = "<group>"; };
 		89878BB11B844E8C004CCD77 /* FeedViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FeedViewController.swift; path = Classes/Controllers/FeedViewController.swift; sourceTree = "<group>"; };
@@ -114,7 +114,7 @@
 				6B8256001B8ACB8D005E2397 /* UserViewController.swift */,
 				89A0FFF11B8D7BB000652A4B /* LoginViewController.swift */,
 				6BEBBBE91B8EED81007EEF4A /* SignupViewController.swift */,
-				6BF845CA1B956BE700BDFA11 /* PasswordResetViewController.swift */,
+				6BF845CA1B956BE700BDFA11 /* ForgotPasswordViewController.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -387,7 +387,7 @@
 				6B8256011B8ACB8D005E2397 /* UserViewController.swift in Sources */,
 				89878BB21B844E8C004CCD77 /* FeedViewController.swift in Sources */,
 				6B8255FD1B8AC8BA005E2397 /* UserTableViewCell.swift in Sources */,
-				6BF845CB1B956BE700BDFA11 /* PasswordResetViewController.swift in Sources */,
+				6BF845CB1B956BE700BDFA11 /* ForgotPasswordViewController.swift in Sources */,
 				6B8256091B8AE755005E2397 /* User.swift in Sources */,
 				89878BAB1B842B41004CCD77 /* Micropost.swift in Sources */,
 				AB55C03A1B8304830077C16C /* AppDelegate.swift in Sources */,

--- a/FoodTracker/Classes/Controllers/ForgotPasswordViewController.swift
+++ b/FoodTracker/Classes/Controllers/ForgotPasswordViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import SVProgressHUD
 
-class PasswordResetViewController: UIViewController, UITextFieldDelegate {
+class ForgotPasswordViewController: UIViewController, UITextFieldDelegate {
     // MARK: - Properties
     @IBOutlet weak var emailTextField: UITextField!
     @IBOutlet weak var submitButton: UIButton!
@@ -12,7 +12,7 @@ class PasswordResetViewController: UIViewController, UITextFieldDelegate {
 
     // MARK: - Actions
     @IBAction func touchSubmitButton(sender: UIButton) {
-        resetPassword()
+        forgotPassword()
     }
 
     @IBAction func unFocusTextField(sender: UITapGestureRecognizer) {
@@ -27,7 +27,7 @@ class PasswordResetViewController: UIViewController, UITextFieldDelegate {
     }
 
     // MARK: -
-    private func resetPassword() {
+    private func forgotPassword() {
         emailTextField.resignFirstResponder()
         SVProgressHUD.showWithStatus("", maskType: .Black)
         if checkValidForm() {

--- a/FoodTracker/Classes/Storyboards/Main.storyboard
+++ b/FoodTracker/Classes/Storyboards/Main.storyboard
@@ -426,6 +426,9 @@ App</string>
                                 <state key="normal" title=" Forgot">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <segue destination="hP3-Uk-Rju" kind="presentation" id="X5K-Ek-vEb"/>
+                                </connections>
                             </button>
                             <textField opaque="NO" clipsSubviews="YES" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Email" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="JCQ-IN-0lf">
                                 <rect key="frame" x="0.0" y="-30" width="97" height="30"/>
@@ -825,26 +828,6 @@ App</string>
                                                 </label>
                                             </subviews>
                                         </tableViewCellContentView>
-                                    </tableViewCell>
-                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="aVx-ih-r6G" style="IBUITableViewCellStyleDefault" id="ojU-gs-noN">
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ojU-gs-noN" id="gzz-p2-fD2">
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Password reset" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="aVx-ih-r6G">
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                    <nil key="highlightedColor"/>
-                                                    <variation key="widthClass=compact">
-                                                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    </variation>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                        <connections>
-                                            <segue destination="n3Q-aK-tkN" kind="show" id="8mX-gT-spZ"/>
-                                        </connections>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
@@ -1334,7 +1317,23 @@ App</string>
             </objects>
             <point key="canvasLocation" x="1756.5" y="1183"/>
         </scene>
-        <!--Password reset-->
+        <!--Navigation Controller-->
+        <scene sceneID="iYR-mB-dly">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="hP3-Uk-Rju" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="Xay-YF-LEp">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="n3Q-aK-tkN" kind="relationship" relationship="rootViewController" id="nfX-dk-770"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="yKv-tF-HhG" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1308" y="1100"/>
+        </scene>
+        <!--Forgot password-->
         <scene sceneID="n8S-Vs-cCn">
             <objects>
                 <viewController id="n3Q-aK-tkN" customClass="PasswordResetViewController" customModule="FoodTracker" customModuleProvider="target" sceneMemberID="viewController">
@@ -1413,7 +1412,13 @@ App</string>
                             <outletCollection property="gestureRecognizers" destination="bDy-xL-gP1" appends="YES" id="sBY-Ke-BMP"/>
                         </connections>
                     </view>
-                    <navigationItem key="navigationItem" title="Password reset" id="vz1-Sl-fRY"/>
+                    <navigationItem key="navigationItem" title="Forgot password" id="ZwZ-dn-WTt">
+                        <barButtonItem key="leftBarButtonItem" systemItem="cancel" id="aR1-mr-d67">
+                            <connections>
+                                <segue destination="KDD-nb-63e" kind="presentation" id="eph-rC-yrT"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <outlet property="emailTextField" destination="LgQ-YN-Afq" id="VBa-0c-JrC"/>
                         <outlet property="submitButton" destination="uLL-Up-H4B" id="B6S-VU-Uks"/>
@@ -1426,7 +1431,7 @@ App</string>
                     </connections>
                 </tapGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="120" y="1419"/>
+            <point key="canvasLocation" x="-603" y="1100"/>
         </scene>
         <!--Profile-->
         <scene sceneID="cpi-Lj-QyF">
@@ -1627,4 +1632,7 @@ App</string>
         <image name="Image" width="320" height="320"/>
         <image name="micropost1" width="400" height="264"/>
     </resources>
+    <inferredMetricsTieBreakers>
+        <segue reference="eph-rC-yrT"/>
+    </inferredMetricsTieBreakers>
 </document>

--- a/FoodTracker/Classes/Storyboards/Main.storyboard
+++ b/FoodTracker/Classes/Storyboards/Main.storyboard
@@ -1336,7 +1336,7 @@ App</string>
         <!--Forgot password-->
         <scene sceneID="n8S-Vs-cCn">
             <objects>
-                <viewController id="n3Q-aK-tkN" customClass="PasswordResetViewController" customModule="FoodTracker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="n3Q-aK-tkN" customClass="ForgotPasswordViewController" customModule="FoodTracker" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="8rm-yd-Rm0"/>
                         <viewControllerLayoutGuide type="bottom" id="WUl-xJ-36Z"/>


### PR DESCRIPTION
きちんとログイン前のforgetからいけるように修正しました:bow:
また、reset passwordからforgot passwordに名前を変更しています。
## マージ条件
- @takuminnnn or @alotofwe が確認する
  - forgotからパスワードリセット画面へ遷移できる
  - Configにパスワードリセットへの遷移がない
