### PR TITLE
パスワードを再設定する画面を作成

### DIFF
--- a/FoodTracker.xcodeproj/project.pbxproj
+++ b/FoodTracker.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		6B8256091B8AE755005E2397 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8256081B8AE754005E2397 /* User.swift */; };
 		6B82560A1B8AE755005E2397 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8256081B8AE754005E2397 /* User.swift */; };
 		6B82560C1B8AE79D005E2397 /* UserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B82560B1B8AE79D005E2397 /* UserTests.swift */; };
+		6BB1A5391B9595A200813021 /* ResetPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB1A5381B9595A200813021 /* ResetPasswordViewController.swift */; };
 		6BEBBBEA1B8EED81007EEF4A /* SignupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEBBBE91B8EED81007EEF4A /* SignupViewController.swift */; };
 		6BF845CB1B956BE700BDFA11 /* ForgotPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF845CA1B956BE700BDFA11 /* ForgotPasswordViewController.swift */; };
 		8969712F1B93F5C500B0CB4C /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969712E1B93F5C500B0CB4C /* Router.swift */; };
@@ -47,6 +48,7 @@
 		6B8256001B8ACB8D005E2397 /* UserViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserViewController.swift; path = Classes/Controllers/UserViewController.swift; sourceTree = "<group>"; };
 		6B8256081B8AE754005E2397 /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = User.swift; path = Classes/Models/User.swift; sourceTree = "<group>"; };
 		6B82560B1B8AE79D005E2397 /* UserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserTests.swift; path = FoodTrackerTests/UserTests.swift; sourceTree = SOURCE_ROOT; };
+		6BB1A5381B9595A200813021 /* ResetPasswordViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ResetPasswordViewController.swift; path = Classes/Controllers/ResetPasswordViewController.swift; sourceTree = "<group>"; };
 		6BEBBBE91B8EED81007EEF4A /* SignupViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SignupViewController.swift; path = Classes/Controllers/SignupViewController.swift; sourceTree = "<group>"; };
 		6BF845CA1B956BE700BDFA11 /* ForgotPasswordViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ForgotPasswordViewController.swift; path = Classes/Controllers/ForgotPasswordViewController.swift; sourceTree = "<group>"; };
 		8969712E1B93F5C500B0CB4C /* Router.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Router.swift; path = Classes/Models/Router.swift; sourceTree = "<group>"; };
@@ -115,6 +117,7 @@
 				89A0FFF11B8D7BB000652A4B /* LoginViewController.swift */,
 				6BEBBBE91B8EED81007EEF4A /* SignupViewController.swift */,
 				6BF845CA1B956BE700BDFA11 /* ForgotPasswordViewController.swift */,
+				6BB1A5381B9595A200813021 /* ResetPasswordViewController.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -389,6 +392,7 @@
 				6B8255FD1B8AC8BA005E2397 /* UserTableViewCell.swift in Sources */,
 				6BF845CB1B956BE700BDFA11 /* ForgotPasswordViewController.swift in Sources */,
 				6B8256091B8AE755005E2397 /* User.swift in Sources */,
+				6BB1A5391B9595A200813021 /* ResetPasswordViewController.swift in Sources */,
 				89878BAB1B842B41004CCD77 /* Micropost.swift in Sources */,
 				AB55C03A1B8304830077C16C /* AppDelegate.swift in Sources */,
 				AB785DDE1B846EED002DA142 /* MicropostlViewController.swift in Sources */,

--- a/FoodTracker/Classes/Controllers/ResetPasswordViewController.swift
+++ b/FoodTracker/Classes/Controllers/ResetPasswordViewController.swift
@@ -1,5 +1,62 @@
 import UIKit
+import SVProgressHUD
 
-class ResetPasswordViewController: UIViewController {
+class ResetPasswordViewController: UIViewController, UITextFieldDelegate {
+    // MARK: - Properties
+    @IBOutlet var textFields: [UITextField]!
+    @IBOutlet weak var updateButton: UIButton!
 
+    // MARK: - View Events
+    override func viewDidLoad() {
+        updateButton.enabled = checkPresenceField()
+    }
+
+    // MARK: - Actions
+    @IBAction func touchUpdateButton(sender: UIButton) {
+        resetPassword()
+    }
+
+    @IBAction func unFocusTextField(sender: UITapGestureRecognizer) {
+        hideKeyboard()
+    }
+
+    // MARK: - UITextFieldDelegate
+    func textFieldShouldEndEditing(textField: UITextField) -> Bool {
+        updateButton.enabled = checkPresenceField()
+        return true
+    }
+
+    func textFieldShouldReturn(textField: UITextField) -> Bool {
+        if textField.tag == 2 {
+            textField.resignFirstResponder()
+        } else {
+            textFields[textField.tag].becomeFirstResponder()
+        }
+        return false
+    }
+
+    // MARK: -
+    private func resetPassword() {
+        hideKeyboard()
+        SVProgressHUD.showWithStatus("", maskType: .Black)
+        if checkPresenceField() {
+            SVProgressHUD.showSuccessWithStatus("", maskType: .Black)
+        } else {
+            SVProgressHUD.showErrorWithStatus("", maskType: .Black)
+        }
+    }
+
+    func checkPresenceField() -> Bool{
+        var result = true
+        for textField : UITextField in textFields {
+            result = result && textField.hasText()
+        }
+        return result
+    }
+
+    private func hideKeyboard() {
+        for textField : UITextField in textFields {
+        textField.resignFirstResponder()
+        }
+    }
 }

--- a/FoodTracker/Classes/Controllers/ResetPasswordViewController.swift
+++ b/FoodTracker/Classes/Controllers/ResetPasswordViewController.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+class ResetPasswordViewController: UIViewController {
+
+}

--- a/FoodTracker/Classes/Storyboards/Main.storyboard
+++ b/FoodTracker/Classes/Storyboards/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="Tu5-Lm-ZQY">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="KDD-nb-63e">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
         <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
@@ -1184,7 +1184,8 @@ App</string>
                                                 <exclude reference="x8g-ZE-7FO"/>
                                             </mask>
                                         </variation>
-                                        <variation key="widthClass=compact">
+                                        <variation key="widthClass=compact" misplaced="YES">
+                                            <rect key="frame" x="8" y="104" width="284" height="451"/>
                                             <mask key="subviews">
                                                 <include reference="FLb-Ac-Zau"/>
                                                 <include reference="gUU-zN-14g"/>
@@ -1264,7 +1265,8 @@ App</string>
                                         <exclude reference="ZPB-36-QK4"/>
                                     </mask>
                                 </variation>
-                                <variation key="widthClass=compact">
+                                <variation key="widthClass=compact" misplaced="YES">
+                                    <rect key="frame" x="50" y="28" width="300" height="564"/>
                                     <mask key="subviews">
                                         <include reference="JQb-NA-4rz"/>
                                         <include reference="N2L-zN-hae"/>
@@ -1336,7 +1338,7 @@ App</string>
         <!--Navigation Controller-->
         <scene sceneID="Epw-3f-oeW">
             <objects>
-                <navigationController id="Tu5-Lm-ZQY" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="ResetPasswordNavigationController" id="Tu5-Lm-ZQY" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="0Km-4j-TFH">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -1762,6 +1764,6 @@ App</string>
         <image name="micropost1" width="400" height="264"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="eph-rC-yrT"/>
+        <segue reference="QdC-QQ-cHK"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/FoodTracker/Classes/Storyboards/Main.storyboard
+++ b/FoodTracker/Classes/Storyboards/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="KDD-nb-63e">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="Tu5-Lm-ZQY">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
         <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
@@ -1184,7 +1184,8 @@ App</string>
                                                 <exclude reference="x8g-ZE-7FO"/>
                                             </mask>
                                         </variation>
-                                        <variation key="widthClass=compact">
+                                        <variation key="widthClass=compact" misplaced="YES">
+                                            <rect key="frame" x="8" y="104" width="284" height="51"/>
                                             <mask key="subviews">
                                                 <include reference="FLb-Ac-Zau"/>
                                                 <include reference="gUU-zN-14g"/>
@@ -1264,7 +1265,8 @@ App</string>
                                         <exclude reference="ZPB-36-QK4"/>
                                     </mask>
                                 </variation>
-                                <variation key="widthClass=compact">
+                                <variation key="widthClass=compact" misplaced="YES">
+                                    <rect key="frame" x="50" y="8" width="300" height="164"/>
                                     <mask key="subviews">
                                         <include reference="JQb-NA-4rz"/>
                                         <include reference="N2L-zN-hae"/>
@@ -1332,6 +1334,123 @@ App</string>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="yKv-tF-HhG" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-1308" y="1100"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="Epw-3f-oeW">
+            <objects>
+                <navigationController id="Tu5-Lm-ZQY" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="0Km-4j-TFH">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="VTR-mg-paA" kind="relationship" relationship="rootViewController" id="6CR-Fu-yvQ"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="eTz-ln-0mi" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1308" y="1793"/>
+        </scene>
+        <!--Reset password-->
+        <scene sceneID="Qpj-Dl-cWS">
+            <objects>
+                <viewController id="VTR-mg-paA" customClass="ResetPasswordViewController" customModule="FoodTracker" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="DZr-bX-6xK"/>
+                        <viewControllerLayoutGuide type="bottom" id="o8m-xS-oSL"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="BQm-mt-ajW">
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textField opaque="NO" clipsSubviews="YES" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Dud-9d-LQj">
+                                <rect key="frame" x="0.0" y="-30" width="97" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="250" id="44A-YX-qeo"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" keyboardType="alphabet" returnKeyType="next" secureTextEntry="YES"/>
+                                <variation key="default">
+                                    <mask key="constraints">
+                                        <exclude reference="44A-YX-qeo"/>
+                                    </mask>
+                                </variation>
+                                <variation key="widthClass=compact">
+                                    <mask key="constraints">
+                                        <include reference="44A-YX-qeo"/>
+                                    </mask>
+                                </variation>
+                                <connections>
+                                    <outlet property="delegate" destination="VTR-mg-paA" id="T0q-sg-jOF"/>
+                                </connections>
+                            </textField>
+                            <textField opaque="NO" clipsSubviews="YES" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Confirmation" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="y5Y-a1-WCO">
+                                <rect key="frame" x="0.0" y="-30" width="97" height="30"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" keyboardType="alphabet" returnKeyType="done" secureTextEntry="YES"/>
+                                <connections>
+                                    <outlet property="delegate" destination="VTR-mg-paA" id="Vki-c2-t6C"/>
+                                </connections>
+                            </textField>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hOj-Cf-h6b">
+                                <rect key="frame" x="-23" y="-15" width="46" height="30"/>
+                                <state key="normal" title="Update password">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <gestureRecognizers/>
+                        <constraints>
+                            <constraint firstItem="hOj-Cf-h6b" firstAttribute="top" secondItem="y5Y-a1-WCO" secondAttribute="bottom" constant="50" id="1Pr-SM-4jr"/>
+                            <constraint firstAttribute="centerX" secondItem="y5Y-a1-WCO" secondAttribute="centerX" id="2T7-Fs-O0W"/>
+                            <constraint firstAttribute="centerX" secondItem="hOj-Cf-h6b" secondAttribute="centerX" id="6kA-Xn-Nzp"/>
+                            <constraint firstItem="Dud-9d-LQj" firstAttribute="top" secondItem="DZr-bX-6xK" secondAttribute="bottom" constant="100" id="I5K-Aa-1bm"/>
+                            <constraint firstAttribute="centerX" secondItem="Dud-9d-LQj" secondAttribute="centerX" id="gmc-L4-QK0"/>
+                            <constraint firstItem="y5Y-a1-WCO" firstAttribute="top" secondItem="Dud-9d-LQj" secondAttribute="bottom" constant="30" id="hx3-xd-H93"/>
+                            <constraint firstItem="Dud-9d-LQj" firstAttribute="width" secondItem="y5Y-a1-WCO" secondAttribute="width" id="iAX-I7-QEc"/>
+                        </constraints>
+                        <variation key="default">
+                            <mask key="subviews">
+                                <exclude reference="Dud-9d-LQj"/>
+                                <exclude reference="y5Y-a1-WCO"/>
+                                <exclude reference="hOj-Cf-h6b"/>
+                            </mask>
+                            <mask key="constraints">
+                                <exclude reference="I5K-Aa-1bm"/>
+                                <exclude reference="gmc-L4-QK0"/>
+                                <exclude reference="iAX-I7-QEc"/>
+                                <exclude reference="2T7-Fs-O0W"/>
+                                <exclude reference="hx3-xd-H93"/>
+                                <exclude reference="1Pr-SM-4jr"/>
+                                <exclude reference="6kA-Xn-Nzp"/>
+                            </mask>
+                        </variation>
+                        <variation key="widthClass=compact">
+                            <mask key="subviews">
+                                <include reference="Dud-9d-LQj"/>
+                                <include reference="y5Y-a1-WCO"/>
+                                <include reference="hOj-Cf-h6b"/>
+                            </mask>
+                            <mask key="constraints">
+                                <include reference="I5K-Aa-1bm"/>
+                                <include reference="gmc-L4-QK0"/>
+                                <include reference="iAX-I7-QEc"/>
+                                <include reference="2T7-Fs-O0W"/>
+                                <include reference="hx3-xd-H93"/>
+                                <include reference="1Pr-SM-4jr"/>
+                                <include reference="6kA-Xn-Nzp"/>
+                            </mask>
+                        </variation>
+                        <connections>
+                            <outletCollection property="gestureRecognizers" destination="Pt8-K9-tF3" appends="YES" id="LNb-x3-U99"/>
+                        </connections>
+                    </view>
+                    <navigationItem key="navigationItem" title="Reset password" id="nHa-EP-apq"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="v7L-kc-j3H" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <tapGestureRecognizer id="Pt8-K9-tF3"/>
+            </objects>
+            <point key="canvasLocation" x="-603" y="1793"/>
         </scene>
         <!--Forgot password-->
         <scene sceneID="n8S-Vs-cCn">

--- a/FoodTracker/Classes/Storyboards/Main.storyboard
+++ b/FoodTracker/Classes/Storyboards/Main.storyboard
@@ -1184,8 +1184,7 @@ App</string>
                                                 <exclude reference="x8g-ZE-7FO"/>
                                             </mask>
                                         </variation>
-                                        <variation key="widthClass=compact" misplaced="YES">
-                                            <rect key="frame" x="8" y="104" width="284" height="51"/>
+                                        <variation key="widthClass=compact">
                                             <mask key="subviews">
                                                 <include reference="FLb-Ac-Zau"/>
                                                 <include reference="gUU-zN-14g"/>
@@ -1265,8 +1264,7 @@ App</string>
                                         <exclude reference="ZPB-36-QK4"/>
                                     </mask>
                                 </variation>
-                                <variation key="widthClass=compact" misplaced="YES">
-                                    <rect key="frame" x="50" y="8" width="300" height="164"/>
+                                <variation key="widthClass=compact">
                                     <mask key="subviews">
                                         <include reference="JQb-NA-4rz"/>
                                         <include reference="N2L-zN-hae"/>
@@ -1362,7 +1360,7 @@ App</string>
                     <view key="view" contentMode="scaleToFill" id="BQm-mt-ajW">
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" clipsSubviews="YES" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Dud-9d-LQj">
+                            <textField opaque="NO" clipsSubviews="YES" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="Dud-9d-LQj">
                                 <rect key="frame" x="0.0" y="-30" width="97" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="250" id="44A-YX-qeo"/>
@@ -1383,7 +1381,7 @@ App</string>
                                     <outlet property="delegate" destination="VTR-mg-paA" id="T0q-sg-jOF"/>
                                 </connections>
                             </textField>
-                            <textField opaque="NO" clipsSubviews="YES" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Confirmation" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="y5Y-a1-WCO">
+                            <textField opaque="NO" clipsSubviews="YES" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Confirmation" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="y5Y-a1-WCO">
                                 <rect key="frame" x="0.0" y="-30" width="97" height="30"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" keyboardType="alphabet" returnKeyType="done" secureTextEntry="YES"/>
@@ -1396,6 +1394,9 @@ App</string>
                                 <state key="normal" title="Update password">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <action selector="touchUpdateButton:" destination="VTR-mg-paA" eventType="touchUpInside" id="3Cx-U9-wTH"/>
+                                </connections>
                             </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -1446,9 +1447,18 @@ App</string>
                         </connections>
                     </view>
                     <navigationItem key="navigationItem" title="Reset password" id="nHa-EP-apq"/>
+                    <connections>
+                        <outlet property="updateButton" destination="hOj-Cf-h6b" id="IWw-8h-suu"/>
+                        <outletCollection property="textFields" destination="Dud-9d-LQj" collectionClass="NSMutableArray" id="OFS-Vj-kHc"/>
+                        <outletCollection property="textFields" destination="y5Y-a1-WCO" collectionClass="NSMutableArray" id="qrl-5R-4cJ"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="v7L-kc-j3H" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <tapGestureRecognizer id="Pt8-K9-tF3"/>
+                <tapGestureRecognizer id="Pt8-K9-tF3">
+                    <connections>
+                        <action selector="unFocusTextField:" destination="VTR-mg-paA" id="gSQ-H1-IxD"/>
+                    </connections>
+                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="-603" y="1793"/>
         </scene>


### PR DESCRIPTION
ペライチです。
実際にはメールのリンクをクリックして飛ぶはずなので、画面にはidentityをつけています。どこからも遷移できないようになってまし、どこへもいけません。
似たようなコードがあふれていてそろそろ辛くなってきました。
## マージ条件
- @takuminnnn or @alotofwe が確認する
  - `ResetPasswordNavigationController` を初期画面にして
    - パスワードを入力できること
    - パスワードの文字が隠れること
    - なんらかの入力があるとき、Update Password が押せること

---

初期画面の設定はStoryboardから、
`ResetPasswordNavigationController` を選択して、`isInitial ViewController` にチェックをいれてね。
![image](https://cloud.githubusercontent.com/assets/1712281/9599829/daf6ca1e-50d1-11e5-85e4-84bb744c2787.png)
