### PR TITLE
サインアップ後のアクティベートをお願いする通知を表示する

### DIFF
--- a/Kakico/Classes/Controllers/LoginViewController.swift
+++ b/Kakico/Classes/Controllers/LoginViewController.swift
@@ -64,4 +64,8 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
     func login() {
         SVProgressHUD.showWithMaskType(SVProgressHUDMaskType.Black)
     }
+
+    func activationPlease() {
+        println("please...")
+    }
 }

--- a/Kakico/Classes/Controllers/LoginViewController.swift
+++ b/Kakico/Classes/Controllers/LoginViewController.swift
@@ -65,7 +65,7 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
         SVProgressHUD.showWithMaskType(SVProgressHUDMaskType.Black)
     }
 
-    func activationPlease() {
+    func activatePlease() {
         let alert = UIAlertController(title: "", message: "Please check your email to ativate your account.", preferredStyle: UIAlertControllerStyle.Alert)
         let action = UIAlertAction(title: "OK", style: UIAlertActionStyle.Default, handler: { (action:UIAlertAction!) -> Void in })
         alert.addAction(action)

--- a/Kakico/Classes/Controllers/LoginViewController.swift
+++ b/Kakico/Classes/Controllers/LoginViewController.swift
@@ -66,6 +66,10 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
     }
 
     func activationPlease() {
-        println("please...")
+        let alert = UIAlertController(title: "", message: "Please check your email to ativate your account.", preferredStyle: UIAlertControllerStyle.Alert)
+        let action = UIAlertAction(title: "OK", style: UIAlertActionStyle.Default, handler: { (action:UIAlertAction!) -> Void in })
+        alert.addAction(action)
+        self.presentViewController(alert, animated: true, completion: nil)
     }
+
 }

--- a/Kakico/Classes/Controllers/LoginViewController.swift
+++ b/Kakico/Classes/Controllers/LoginViewController.swift
@@ -66,7 +66,7 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
     }
 
     func activatePlease() {
-        let alert = UIAlertController(title: "", message: "Please check your email to ativate your account.", preferredStyle: UIAlertControllerStyle.Alert)
+        let alert = UIAlertController(title: "", message: "Please check your email to activate your account.", preferredStyle: UIAlertControllerStyle.Alert)
         let action = UIAlertAction(title: "OK", style: UIAlertActionStyle.Default, handler: { (action:UIAlertAction!) -> Void in })
         alert.addAction(action)
         self.presentViewController(alert, animated: true, completion: nil)

--- a/Kakico/Classes/Controllers/SignupViewController.swift
+++ b/Kakico/Classes/Controllers/SignupViewController.swift
@@ -77,7 +77,7 @@ class SignupViewController: UIViewController, UITextFieldDelegate {
                 SVProgressHUD.dismiss()
                 let targetViewController = self.storyboard!.instantiateViewControllerWithIdentifier("LoginViewController") as! LoginViewController
                 self.presentViewController(targetViewController, animated: true, completion: nil)
-                targetViewController.activationPlease()
+                targetViewController.activatePlease()
             } else{
                 let tmp = json["messages"]["user"]
                 SVProgressHUD.showErrorWithStatus(json["messages"]["user"].dictionary!.values.first?.stringValue)

--- a/Kakico/Classes/Controllers/SignupViewController.swift
+++ b/Kakico/Classes/Controllers/SignupViewController.swift
@@ -75,8 +75,9 @@ class SignupViewController: UIViewController, UITextFieldDelegate {
             println(json["status"])
             if json["status"] == 200 {
                 SVProgressHUD.dismiss()
-                let targetViewController = self.storyboard!.instantiateViewControllerWithIdentifier("FeedNavigationController") as! UIViewController
-                self.presentViewController( targetViewController, animated: true, completion: nil)
+                let targetViewController = self.storyboard!.instantiateViewControllerWithIdentifier("LoginViewController") as! LoginViewController
+                self.presentViewController(targetViewController, animated: true, completion: nil)
+                targetViewController.activationPlease()
             } else{
                 let tmp = json["messages"]["user"]
                 SVProgressHUD.showErrorWithStatus(json["messages"]["user"].dictionary!.values.first?.stringValue)

--- a/Kakico/Classes/Storyboards/Main.storyboard
+++ b/Kakico/Classes/Storyboards/Main.storyboard
@@ -372,7 +372,7 @@
         <!--Login View Controller-->
         <scene sceneID="MLw-rH-x4A">
             <objects>
-                <viewController id="KDD-nb-63e" customClass="LoginViewController" customModule="Kakico" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LoginViewController" id="KDD-nb-63e" customClass="LoginViewController" customModule="Kakico" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="j4B-Gq-Oix"/>
                         <viewControllerLayoutGuide type="bottom" id="s9q-U1-ifr"/>
@@ -1164,8 +1164,7 @@
                                                 <exclude reference="x8g-ZE-7FO"/>
                                             </mask>
                                         </variation>
-                                        <variation key="widthClass=compact" misplaced="YES">
-                                            <rect key="frame" x="8" y="104" width="284" height="50.5"/>
+                                        <variation key="widthClass=compact">
                                             <mask key="subviews">
                                                 <include reference="FLb-Ac-Zau"/>
                                                 <include reference="gUU-zN-14g"/>


### PR DESCRIPTION
当初は画面でアクティベートを促す、という話でしたが、Webの方の挙動にあわせて、AlertViewでお知らせするようにしています。
## マージ条件
- @takuminnnn or @alotofwe が
  - サインアップしたとき、アラートビューが確認できる
  - アラートビューをOKするとアラートが消える
