### PR TITLE
ユーザ認証

### DIFF
--- a/Kakico/AppDelegate.swift
+++ b/Kakico/AppDelegate.swift
@@ -1,12 +1,13 @@
 import UIKit
 import Alamofire
+import KeychainAccess
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
+    
     var window: UIWindow?
-
-
+    
+    
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         let manager = Alamofire.Manager.sharedInstance
         
@@ -31,7 +32,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             
             return (disposition, credential)
         }
-
+        
         return true
     }
     
@@ -51,28 +52,38 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             params = getParamsFromURL(url)
         }
         
+        println(application)
+        println(url)
+        println(sourceApplication)
+        println(annotation)
+        
+        if let auth_token = params["auth_token"] {
+            var keychain = Keychain(service: "nehan.Kakico")
+            keychain["auth_token"] = auth_token
+        }
+        
         return true
     }
     
     func applicationWillResignActive(application: UIApplication) {
     }
-
+    
     func applicationDidEnterBackground(application: UIApplication) {
     }
-
+    
     func applicationWillEnterForeground(application: UIApplication) {
     }
-
+    
     func applicationDidBecomeActive(application: UIApplication) {
     }
-
+    
     func applicationWillTerminate(application: UIApplication) {
     }
-
+    
     func getControllerIdentifierFromURL(url: NSURL) -> String {
         return url.host!.capitalizedString + "NavigationController"
     }
-
+    
     func getParamsFromURL(url: NSURL) -> Dictionary<String, String> {
         var params = Dictionary<String, String>()
         if let query = url.query as String! {

--- a/Kakico/AppDelegate.swift
+++ b/Kakico/AppDelegate.swift
@@ -32,7 +32,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             
             return (disposition, credential)
         }
-        
+
         return true
     }
 

--- a/Kakico/AppDelegate.swift
+++ b/Kakico/AppDelegate.swift
@@ -4,10 +4,10 @@ import KeychainAccess
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    
+
     var window: UIWindow?
-    
-    
+
+
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         let manager = Alamofire.Manager.sharedInstance
         
@@ -35,7 +35,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         return true
     }
-    
+
     func application(application: UIApplication, openURL url: NSURL, sourceApplication: String?, annotation: AnyObject?) -> Bool {
         
         if url.host != nil {
@@ -64,26 +64,26 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         return true
     }
-    
+
     func applicationWillResignActive(application: UIApplication) {
     }
-    
+
     func applicationDidEnterBackground(application: UIApplication) {
     }
-    
+
     func applicationWillEnterForeground(application: UIApplication) {
     }
-    
+
     func applicationDidBecomeActive(application: UIApplication) {
     }
-    
+
     func applicationWillTerminate(application: UIApplication) {
     }
-    
+
     func getControllerIdentifierFromURL(url: NSURL) -> String {
         return url.host!.capitalizedString + "NavigationController"
     }
-    
+
     func getParamsFromURL(url: NSURL) -> Dictionary<String, String> {
         var params = Dictionary<String, String>()
         if let query = url.query as String! {

--- a/Kakico/Classes/Models/Router.swift
+++ b/Kakico/Classes/Models/Router.swift
@@ -1,4 +1,5 @@
 import Alamofire
+import KeychainAccess
 
 enum Router: URLRequestConvertible {
     static let baseURLString = "http://localhost:3000"
@@ -36,6 +37,11 @@ enum Router: URLRequestConvertible {
         let mutableURLRequest = NSMutableURLRequest(URL: URL.URLByAppendingPathComponent(path))
         mutableURLRequest.HTTPMethod = method.rawValue
         
+        let keychain = Keychain(service: "nehan.Kakico")
+        if let auth_token = keychain["auth_token"] {
+            mutableURLRequest.setValue(auth_token, forHTTPHeaderField: "Authorization")
+        }
+
         switch self {
         case .PostUser(let parameters):
             return Alamofire.ParameterEncoding.JSON.encode(mutableURLRequest, parameters: parameters).0

--- a/Podfile
+++ b/Podfile
@@ -6,6 +6,7 @@ pod 'Alamofire', '~> 1.3'
 pod 'SVProgressHUD'
 pod 'SwiftyJSON', '~> 2.2.1'
 pod 'SDWebImage'
+pod 'KeychainAccess'
 
 target 'Kakico' do
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,6 @@
 PODS:
   - Alamofire (1.3.1)
+  - KeychainAccess (1.2.1)
   - SDWebImage (3.7.3):
     - SDWebImage/Core (= 3.7.3)
   - SDWebImage/Core (3.7.3)
@@ -8,12 +9,14 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire (~> 1.3)
+  - KeychainAccess
   - SDWebImage
   - SVProgressHUD
   - SwiftyJSON (~> 2.2.1)
 
 SPEC CHECKSUMS:
   Alamofire: e4ab637e3195b645c814b87a652373439e59f2a4
+  KeychainAccess: 3d7922baf90762a976adb7f6030d74c1a4110a1d
   SDWebImage: 1d2b1a1efda1ade1b00b6f8498865f8ddedc8a84
   SVProgressHUD: 748080e4f36e603f6c02aec292664239df5279c1
   SwiftyJSON: ae2d0a3d68025d136602a33c4ee215091ced3e33


### PR DESCRIPTION
1. URL経由でアプリを立ち上げた際に，URL内にパラメータとしてauth_token=xxxxが存在する場合は，keychainに`keychain["auth_token"] = xxxxx`と保存をします
2. APIを叩く際，keychainにauth_tokenが存在する場合は，**APIの種類に関わらず**Authorization headerに値をセットします
# Close条件
- [x] Passed CI tests
- [x] @takuminnnn or @orzup :ok: 
