### PR TITLE
ユーザリストから各ユーザのprofileに遷移させる

### DIFF
--- a/Kakico.xcodeproj/project.pbxproj
+++ b/Kakico.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		6BEBBBEA1B8EED81007EEF4A /* SignupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEBBBE91B8EED81007EEF4A /* SignupViewController.swift */; };
 		6BF845CB1B956BE700BDFA11 /* ForgotPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF845CA1B956BE700BDFA11 /* ForgotPasswordViewController.swift */; };
 		893C220B1B9835EE00C006E4 /* MicropostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 893C220A1B9835EE00C006E4 /* MicropostViewController.swift */; };
+		893C220D1B983F9300C006E4 /* ProfileHeaderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 893C220C1B983F9300C006E4 /* ProfileHeaderViewController.swift */; };
 		8969712F1B93F5C500B0CB4C /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969712E1B93F5C500B0CB4C /* Router.swift */; };
 		89878BAB1B842B41004CCD77 /* Micropost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89878BAA1B842B41004CCD77 /* Micropost.swift */; };
 		89878BAC1B842B41004CCD77 /* Micropost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89878BAA1B842B41004CCD77 /* Micropost.swift */; };
@@ -55,6 +56,7 @@
 		6BEBBBE91B8EED81007EEF4A /* SignupViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SignupViewController.swift; path = Controllers/SignupViewController.swift; sourceTree = "<group>"; };
 		6BF845CA1B956BE700BDFA11 /* ForgotPasswordViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ForgotPasswordViewController.swift; path = Controllers/ForgotPasswordViewController.swift; sourceTree = "<group>"; };
 		893C220A1B9835EE00C006E4 /* MicropostViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MicropostViewController.swift; path = Controllers/MicropostViewController.swift; sourceTree = "<group>"; };
+		893C220C1B983F9300C006E4 /* ProfileHeaderViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProfileHeaderViewController.swift; path = Controllers/ProfileHeaderViewController.swift; sourceTree = "<group>"; };
 		8969712E1B93F5C500B0CB4C /* Router.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		89878BAA1B842B41004CCD77 /* Micropost.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Micropost.swift; sourceTree = "<group>"; };
 		89878BB11B844E8C004CCD77 /* FeedViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FeedViewController.swift; path = Controllers/FeedViewController.swift; sourceTree = "<group>"; };
@@ -127,6 +129,7 @@
 				89DAD6181B96C74300BB43A6 /* ConfigViewController.swift */,
 				89A8F4151B96D7A90014C18E /* ProfileViewController.swift */,
 				893C220A1B9835EE00C006E4 /* MicropostViewController.swift */,
+				893C220C1B983F9300C006E4 /* ProfileHeaderViewController.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -399,6 +402,7 @@
 				89DAD6191B96C74300BB43A6 /* ConfigViewController.swift in Sources */,
 				6B8256011B8ACB8D005E2397 /* UserViewController.swift in Sources */,
 				89878BB21B844E8C004CCD77 /* FeedViewController.swift in Sources */,
+				893C220D1B983F9300C006E4 /* ProfileHeaderViewController.swift in Sources */,
 				893C220B1B9835EE00C006E4 /* MicropostViewController.swift in Sources */,
 				6B8255FD1B8AC8BA005E2397 /* UserTableViewCell.swift in Sources */,
 				6BF845CB1B956BE700BDFA11 /* ForgotPasswordViewController.swift in Sources */,

--- a/Kakico.xcodeproj/project.pbxproj
+++ b/Kakico.xcodeproj/project.pbxproj
@@ -296,6 +296,7 @@
 				TargetAttributes = {
 					AB55C0331B8304830077C16C = {
 						CreatedOnToolsVersion = 6.4;
+						DevelopmentTeam = NH7E35TW7H;
 					};
 					AB55C0481B8304830077C16C = {
 						CreatedOnToolsVersion = 6.4;
@@ -529,9 +530,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = "$(SRCROOT)/Kakico/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = Kakico;
+				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Kakico/Kakico-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = 1;
 			};
@@ -543,9 +546,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = "$(SRCROOT)/Kakico/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = Kakico;
+				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Kakico/Kakico-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = 1;
 			};

--- a/Kakico.xcodeproj/project.pbxproj
+++ b/Kakico.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		6BB1A5391B9595A200813021 /* ResetPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB1A5381B9595A200813021 /* ResetPasswordViewController.swift */; };
 		6BEBBBEA1B8EED81007EEF4A /* SignupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEBBBE91B8EED81007EEF4A /* SignupViewController.swift */; };
 		6BF845CB1B956BE700BDFA11 /* ForgotPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF845CA1B956BE700BDFA11 /* ForgotPasswordViewController.swift */; };
+		893C220B1B9835EE00C006E4 /* MicropostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 893C220A1B9835EE00C006E4 /* MicropostViewController.swift */; };
 		8969712F1B93F5C500B0CB4C /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969712E1B93F5C500B0CB4C /* Router.swift */; };
 		89878BAB1B842B41004CCD77 /* Micropost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89878BAA1B842B41004CCD77 /* Micropost.swift */; };
 		89878BAC1B842B41004CCD77 /* Micropost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89878BAA1B842B41004CCD77 /* Micropost.swift */; };
@@ -53,6 +54,7 @@
 		6BB1A5381B9595A200813021 /* ResetPasswordViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ResetPasswordViewController.swift; path = Controllers/ResetPasswordViewController.swift; sourceTree = "<group>"; };
 		6BEBBBE91B8EED81007EEF4A /* SignupViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SignupViewController.swift; path = Controllers/SignupViewController.swift; sourceTree = "<group>"; };
 		6BF845CA1B956BE700BDFA11 /* ForgotPasswordViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ForgotPasswordViewController.swift; path = Controllers/ForgotPasswordViewController.swift; sourceTree = "<group>"; };
+		893C220A1B9835EE00C006E4 /* MicropostViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MicropostViewController.swift; path = Controllers/MicropostViewController.swift; sourceTree = "<group>"; };
 		8969712E1B93F5C500B0CB4C /* Router.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		89878BAA1B842B41004CCD77 /* Micropost.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Micropost.swift; sourceTree = "<group>"; };
 		89878BB11B844E8C004CCD77 /* FeedViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FeedViewController.swift; path = Controllers/FeedViewController.swift; sourceTree = "<group>"; };
@@ -124,6 +126,7 @@
 				6BB1A5381B9595A200813021 /* ResetPasswordViewController.swift */,
 				89DAD6181B96C74300BB43A6 /* ConfigViewController.swift */,
 				89A8F4151B96D7A90014C18E /* ProfileViewController.swift */,
+				893C220A1B9835EE00C006E4 /* MicropostViewController.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -396,6 +399,7 @@
 				89DAD6191B96C74300BB43A6 /* ConfigViewController.swift in Sources */,
 				6B8256011B8ACB8D005E2397 /* UserViewController.swift in Sources */,
 				89878BB21B844E8C004CCD77 /* FeedViewController.swift in Sources */,
+				893C220B1B9835EE00C006E4 /* MicropostViewController.swift in Sources */,
 				6B8255FD1B8AC8BA005E2397 /* UserTableViewCell.swift in Sources */,
 				6BF845CB1B956BE700BDFA11 /* ForgotPasswordViewController.swift in Sources */,
 				6B8256091B8AE755005E2397 /* User.swift in Sources */,

--- a/Kakico/Classes/Controllers/FeedViewController.swift
+++ b/Kakico/Classes/Controllers/FeedViewController.swift
@@ -3,17 +3,8 @@ import SVProgressHUD
 import Alamofire
 import SwiftyJSON
 
-class FeedViewController: UITableViewController {
-    // MARK: - Properties
-    var microposts = MicropostDataManager()
-    
-    // MARK: - View Events
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        request()
-    }
-
-    func request() {
+class FeedViewController: MicropostViewController {
+    override func request() {
         SVProgressHUD.showWithMaskType(.Black)
         Alamofire.request(Router.GetFeed()).responseJSON { (request, response, data, error) -> Void in
             println(data)
@@ -41,40 +32,5 @@ class FeedViewController: UITableViewController {
                 SVProgressHUD.showErrorWithStatus("", maskType: .Black)
             }
         }
-    }
-    
-    // MARK: - Table view data source
-    override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
-        return 1
-    }
-    
-    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return self.microposts.size
-    }
-    
-    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let cellIdentifier = "Micropost"
-        
-        let cell = tableView.dequeueReusableCellWithIdentifier(cellIdentifier, forIndexPath: indexPath) as! MicropostCell
-        
-        let micropost = self.microposts[indexPath.row] as Micropost
-
-        cell.contentLabel.text = micropost.content
-        cell.pictureImageView.sd_setImageWithURL(micropost.picture)
-        
-        return cell
-    }
-    
-    override func tableView(tableView: UITableView, estimatedHeightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-        return 216
-    }
-    
-    override func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-        return UITableViewAutomaticDimension
-    }
-    
-    // MARK: - Navigation
-    @IBAction func unwindToMicropostList(sender: UIStoryboardSegue) {
-        request()
     }
 }

--- a/Kakico/Classes/Controllers/FeedViewController.swift
+++ b/Kakico/Classes/Controllers/FeedViewController.swift
@@ -4,6 +4,12 @@ import Alamofire
 import SwiftyJSON
 
 class FeedViewController: MicropostViewController {
+    // MARK: - View Events
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        request()
+    }
+
     override func request() {
         SVProgressHUD.showWithMaskType(.Black)
         Alamofire.request(Router.GetFeed()).responseJSON { (request, response, data, error) -> Void in

--- a/Kakico/Classes/Controllers/FeedViewController.swift
+++ b/Kakico/Classes/Controllers/FeedViewController.swift
@@ -19,7 +19,8 @@ class FeedViewController: MicropostViewController {
                     }
                     var micropost: Micropost = Micropost(
                         content: subJson["content"].string!,
-                        picture: NSURL(string: picture)
+                        picture: NSURL(string: picture),
+                        user_id: subJson["user_id"].int!
                     )
                     self.microposts.set(micropost)
                 }
@@ -32,5 +33,20 @@ class FeedViewController: MicropostViewController {
                 SVProgressHUD.showErrorWithStatus("", maskType: .Black)
             }
         }
+    }
+
+    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        let cellIdentifier = "Micropost"
+
+        let cell = tableView.dequeueReusableCellWithIdentifier(cellIdentifier, forIndexPath: indexPath) as! MicropostCell
+
+        let micropost = self.microposts[indexPath.row] as Micropost
+
+        cell.contentLabel.text = micropost.content
+        cell.pictureImageView.sd_setImageWithURL(micropost.picture)
+
+        cell.viewWithTag(micropost.user_id)
+
+        return cell
     }
 }

--- a/Kakico/Classes/Controllers/MicropostViewController.swift
+++ b/Kakico/Classes/Controllers/MicropostViewController.swift
@@ -9,11 +9,11 @@ class MicropostViewController: UITableViewController, UITableViewDataSource, UIT
 
     var _selectUserId: Int = 0
 
-    // MARK: - View Events
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        request()
-    }
+//    // MARK: - View Events
+//    override func viewDidLoad() {
+//        super.viewDidLoad()
+//        request()
+//    }
 
     func request() {
         SVProgressHUD.showWithMaskType(.Black)

--- a/Kakico/Classes/Controllers/MicropostViewController.swift
+++ b/Kakico/Classes/Controllers/MicropostViewController.swift
@@ -28,7 +28,8 @@ class MicropostViewController: UITableViewController {
                     }
                     var micropost: Micropost = Micropost(
                         content: subJson["content"].string!,
-                        picture: NSURL(string: picture)
+                        picture: NSURL(string: picture),
+                        user_id: subJson["user_id"].int!
                     )
                     self.microposts.set(micropost)
                 }

--- a/Kakico/Classes/Controllers/MicropostViewController.swift
+++ b/Kakico/Classes/Controllers/MicropostViewController.swift
@@ -3,9 +3,11 @@ import SVProgressHUD
 import Alamofire
 import SwiftyJSON
 
-class MicropostViewController: UITableViewController {
+class MicropostViewController: UITableViewController, UITableViewDataSource, UITableViewDelegate {
     // MARK: - Properties
     var microposts = MicropostDataManager()
+
+    var _selectUserId: Int = 0
 
     // MARK: - View Events
     override func viewDidLoad() {

--- a/Kakico/Classes/Controllers/MicropostViewController.swift
+++ b/Kakico/Classes/Controllers/MicropostViewController.swift
@@ -9,12 +9,6 @@ class MicropostViewController: UITableViewController, UITableViewDataSource, UIT
 
     var _selectUserId: Int = 0
 
-//    // MARK: - View Events
-//    override func viewDidLoad() {
-//        super.viewDidLoad()
-//        request()
-//    }
-
     func request() {
         SVProgressHUD.showWithMaskType(.Black)
         Alamofire.request(Router.GetFeed()).responseJSON { (request, response, data, error) -> Void in

--- a/Kakico/Classes/Controllers/MicropostViewController.swift
+++ b/Kakico/Classes/Controllers/MicropostViewController.swift
@@ -1,0 +1,80 @@
+import UIKit
+import SVProgressHUD
+import Alamofire
+import SwiftyJSON
+
+class MicropostViewController: UITableViewController {
+    // MARK: - Properties
+    var microposts = MicropostDataManager()
+
+    // MARK: - View Events
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        request()
+    }
+
+    func request() {
+        SVProgressHUD.showWithMaskType(.Black)
+        Alamofire.request(Router.GetFeed()).responseJSON { (request, response, data, error) -> Void in
+            println(data)
+            if data != nil {
+                let json = JSON(data!)
+                println(json)
+
+                for (index: String, subJson: JSON) in json["contents"] {
+                    var picture = ""
+                    if let url = subJson["picture"]["url"].string {
+                        picture = url
+                    }
+                    var micropost: Micropost = Micropost(
+                        content: subJson["content"].string!,
+                        picture: NSURL(string: picture)
+                    )
+                    self.microposts.set(micropost)
+                }
+
+                dispatch_async(dispatch_get_main_queue(), {
+                    self.tableView.reloadData()
+                })
+                SVProgressHUD.dismiss()
+            } else {
+                SVProgressHUD.showErrorWithStatus("", maskType: .Black)
+            }
+        }
+    }
+
+    // MARK: - Table view data source
+    override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+        return 1
+    }
+
+    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return self.microposts.size
+    }
+
+    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        let cellIdentifier = "Micropost"
+
+        let cell = tableView.dequeueReusableCellWithIdentifier(cellIdentifier, forIndexPath: indexPath) as! MicropostCell
+
+        let micropost = self.microposts[indexPath.row] as Micropost
+
+        cell.contentLabel.text = micropost.content
+        cell.pictureImageView.sd_setImageWithURL(micropost.picture)
+
+        return cell
+    }
+
+    override func tableView(tableView: UITableView, estimatedHeightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
+        return 216
+    }
+
+    override func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
+        return UITableViewAutomaticDimension
+    }
+
+    // MARK: - Navigation
+    @IBAction func unwindToMicropostList(sender: UIStoryboardSegue) {
+        request()
+    }
+}

--- a/Kakico/Classes/Controllers/ProfileHeaderViewController.swift
+++ b/Kakico/Classes/Controllers/ProfileHeaderViewController.swift
@@ -9,14 +9,16 @@ class ProfileHeaderViewController: UIViewController {
     @IBOutlet weak var postCount: UIButton!
     @IBOutlet weak var followingCount: UIButton!
     @IBOutlet weak var followerCount: UIButton!
+
+    var _selectUserId: Int = 0
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        request()
+        request(_selectUserId)
     }
 
-    func request() {
-        Alamofire.request(Router.GetUser(userId: 1)).responseJSON { (request, response, data, error) -> Void in
+    func request(selectUserId: Int) {
+        Alamofire.request(Router.GetUser(userId: selectUserId)).responseJSON { (request, response, data, error) -> Void in
             println(data)
             if data != nil {
                 let json = JSON(data!)

--- a/Kakico/Classes/Controllers/ProfileHeaderViewController.swift
+++ b/Kakico/Classes/Controllers/ProfileHeaderViewController.swift
@@ -1,0 +1,34 @@
+import UIKit
+import Alamofire
+import SwiftyJSON
+
+class ProfileHeaderViewController: UIViewController {
+    // MARK: - Properties
+    @IBOutlet weak var nameLabel: UILabel!
+    @IBOutlet weak var userIcon: UIImageView!
+    @IBOutlet weak var postCount: UIButton!
+    @IBOutlet weak var followingCount: UIButton!
+    @IBOutlet weak var followerCount: UIButton!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        request()
+    }
+
+    func request() {
+        Alamofire.request(Router.GetUser(userId: 1)).responseJSON { (request, response, data, error) -> Void in
+            println(data)
+            if data != nil {
+                let json = JSON(data!)
+                println(json)
+
+                let contents = json["contents"]
+                self.nameLabel.text = contents["name"].string!
+                self.userIcon.sd_setImageWithURL(NSURL(string: contents["icon_url"].string!))
+                self.postCount.setTitle(contents["microposts_count"].description, forState: .Normal)
+                self.followingCount.setTitle(contents["following_count"].description, forState: .Normal)
+                self.followerCount.setTitle(contents["followers_count"].description, forState: .Normal)
+            }
+        }
+    }
+}

--- a/Kakico/Classes/Controllers/ProfileViewController.swift
+++ b/Kakico/Classes/Controllers/ProfileViewController.swift
@@ -7,18 +7,17 @@ class ProfileViewController: MicropostViewController {
     // MARK: - Properties
     @IBOutlet weak var header: UIView!
 
-    var _userId = 1
-
     override func viewDidLoad() {
         super.viewDidLoad()
-        request(_userId)
+        println("-----------ProfileView-----------")
+        request(super._selectUserId)
 
 //        let hoge = self.childViewControllers.first as! ProfileHeaderViewController
     }
 
-    func request(userId: Int) {
+    func request(selectUserId: Int) {
         SVProgressHUD.showWithMaskType(.Black)
-        Alamofire.request(Router.GetMicroposts(userId: userId)).responseJSON { (request, response, data, error) -> Void in
+        Alamofire.request(Router.GetMicroposts(userId: selectUserId)).responseJSON { (request, response, data, error) -> Void in
             println(data)
             if data != nil {
                 let json = JSON(data!)
@@ -32,7 +31,7 @@ class ProfileViewController: MicropostViewController {
                     var micropost: Micropost = Micropost(
                         content: subJson["content"].string!,
                         picture: NSURL(string: picture),
-                        user_id: subJson["user_id"].int!
+                        user_id: selectUserId
                     )
                     self.microposts.set(micropost)
                 }

--- a/Kakico/Classes/Controllers/ProfileViewController.swift
+++ b/Kakico/Classes/Controllers/ProfileViewController.swift
@@ -8,9 +8,6 @@ class ProfileViewController: MicropostViewController {
     @IBOutlet weak var header: UIView!
 
     override func viewDidLoad() {
-//        var headerView = self.childViewControllers.first as! ProfileHeaderViewController
-//        headerView._selectUserId = super._selectUserId
-
         super.viewDidLoad()
         request(super._selectUserId)
     }

--- a/Kakico/Classes/Controllers/ProfileViewController.swift
+++ b/Kakico/Classes/Controllers/ProfileViewController.swift
@@ -4,18 +4,21 @@ import Alamofire
 import SwiftyJSON
 
 class ProfileViewController: MicropostViewController {
+    // MARK: - Properties
     @IBOutlet weak var header: UIView!
+
+    var _userId = 1
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        request()
+        request(_userId)
 
 //        let hoge = self.childViewControllers.first as! ProfileHeaderViewController
     }
 
-    override func request() {
+    func request(userId: Int) {
         SVProgressHUD.showWithMaskType(.Black)
-        Alamofire.request(Router.GetFeed()).responseJSON { (request, response, data, error) -> Void in
+        Alamofire.request(Router.GetMicroposts(userId: userId)).responseJSON { (request, response, data, error) -> Void in
             println(data)
             if data != nil {
                 let json = JSON(data!)

--- a/Kakico/Classes/Controllers/ProfileViewController.swift
+++ b/Kakico/Classes/Controllers/ProfileViewController.swift
@@ -8,11 +8,11 @@ class ProfileViewController: MicropostViewController {
     @IBOutlet weak var header: UIView!
 
     override func viewDidLoad() {
-        super.viewDidLoad()
-        println("-----------ProfileView-----------")
-        request(super._selectUserId)
+//        var headerView = self.childViewControllers.first as! ProfileHeaderViewController
+//        headerView._selectUserId = super._selectUserId
 
-//        let hoge = self.childViewControllers.first as! ProfileHeaderViewController
+        super.viewDidLoad()
+        request(super._selectUserId)
     }
 
     func request(selectUserId: Int) {
@@ -43,6 +43,14 @@ class ProfileViewController: MicropostViewController {
             } else {
                 SVProgressHUD.showErrorWithStatus("", maskType: .Black)
             }
+        }
+    }
+
+    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject!) {
+        if segue.identifier == "ProfileHeaderView" {
+            var headerView: ProfileHeaderViewController = segue.destinationViewController as! ProfileHeaderViewController
+
+            headerView._selectUserId = self._selectUserId
         }
     }
 }

--- a/Kakico/Classes/Controllers/UserViewController.swift
+++ b/Kakico/Classes/Controllers/UserViewController.swift
@@ -5,6 +5,8 @@ import SwiftyJSON
 class UserViewController: UITableViewController {
     // MARK: - Properties
     var users = UserDataManager()
+
+    var selectedRow: Int?
     var _listType = ""
     
     // MARK: - View Events
@@ -35,11 +37,11 @@ class UserViewController: UITableViewController {
     }
     
     func setUserList(data: AnyObject?) {
-        println(data)
+//        println(data)
         if data != nil {
             let json = JSON(data!)
-            println(json)
-            
+//            println(json)
+
             for (index: String, subJson: JSON) in json["contents"] {
                 var user: User = User(
                     id: subJson["id"].int!,
@@ -63,7 +65,7 @@ class UserViewController: UITableViewController {
     override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return self.users.size
     }
-    
+
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let cellIdentifier = "UserTableViewCell"
         
@@ -71,14 +73,24 @@ class UserViewController: UITableViewController {
         let user = self.users[indexPath.row] as User
         cell.userName.text = user.name
         cell.userIcon.imageView?.sd_setImageWithURL(user.icon)
-        cell.tag = user.id
         
         return cell
     }
 
-    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject!) {
-        var profileView = segue.destinationViewController as! ProfileViewController
+    override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+        println("------------userView - tableView ------------")
+        self.selectedRow = indexPath.row
+        performSegueWithIdentifier("ProfileView", sender: nil)
+    }
 
-        profileView._userId = 1
+    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject!) {
+        if (segue.identifier == "ProfileView") && (self.selectedRow != nil) {
+            var profileView: ProfileViewController = segue.destinationViewController as! ProfileViewController
+
+            println("----------userView-----------")
+            let user = self.users[self.selectedRow!] as User
+            profileView._selectUserId = user.id
+            println(profileView._selectUserId)
+        }
     }
 }

--- a/Kakico/Classes/Controllers/UserViewController.swift
+++ b/Kakico/Classes/Controllers/UserViewController.swift
@@ -77,18 +77,19 @@ class UserViewController: UITableViewController {
         return cell
     }
 
-    override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
-        println("------------userView - tableView ------------")
-        self.selectedRow = indexPath.row
-        performSegueWithIdentifier("ProfileView", sender: nil)
-    }
+//    override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+//        println("------------userView - tableView ------------")
+//        self.selectedRow = indexPath.row
+//        performSegueWithIdentifier("ProfileView", sender: nil)
+//    }
 
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject!) {
-        if (segue.identifier == "ProfileView") && (self.selectedRow != nil) {
+        if segue.identifier == "ProfileView" {
             var profileView: ProfileViewController = segue.destinationViewController as! ProfileViewController
 
             println("----------userView-----------")
-            let user = self.users[self.selectedRow!] as User
+            let indexPath : NSIndexPath = self.tableView.indexPathForSelectedRow()!
+            let user = self.users[indexPath.row] as User
             profileView._selectUserId = user.id
             println(profileView._selectUserId)
         }

--- a/Kakico/Classes/Controllers/UserViewController.swift
+++ b/Kakico/Classes/Controllers/UserViewController.swift
@@ -77,21 +77,15 @@ class UserViewController: UITableViewController {
         return cell
     }
 
-//    override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
-//        println("------------userView - tableView ------------")
-//        self.selectedRow = indexPath.row
-//        performSegueWithIdentifier("ProfileView", sender: nil)
-//    }
-
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject!) {
         if segue.identifier == "ProfileView" {
             var profileView: ProfileViewController = segue.destinationViewController as! ProfileViewController
+//            var headerView: ProfileHeaderViewController = profileView.childViewControllers.first as! ProfileHeaderViewController
 
-            println("----------userView-----------")
             let indexPath : NSIndexPath = self.tableView.indexPathForSelectedRow()!
             let user = self.users[indexPath.row] as User
             profileView._selectUserId = user.id
-            println(profileView._selectUserId)
+//            headerView._selectUserId = user.id
         }
     }
 }

--- a/Kakico/Classes/Controllers/UserViewController.swift
+++ b/Kakico/Classes/Controllers/UserViewController.swift
@@ -37,10 +37,10 @@ class UserViewController: UITableViewController {
     }
     
     func setUserList(data: AnyObject?) {
-//        println(data)
+        println(data)
         if data != nil {
             let json = JSON(data!)
-//            println(json)
+            println(json)
 
             for (index: String, subJson: JSON) in json["contents"] {
                 var user: User = User(
@@ -80,12 +80,10 @@ class UserViewController: UITableViewController {
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject!) {
         if segue.identifier == "ProfileView" {
             var profileView: ProfileViewController = segue.destinationViewController as! ProfileViewController
-//            var headerView: ProfileHeaderViewController = profileView.childViewControllers.first as! ProfileHeaderViewController
 
             let indexPath : NSIndexPath = self.tableView.indexPathForSelectedRow()!
             let user = self.users[indexPath.row] as User
             profileView._selectUserId = user.id
-//            headerView._selectUserId = user.id
         }
     }
 }

--- a/Kakico/Classes/Controllers/UserViewController.swift
+++ b/Kakico/Classes/Controllers/UserViewController.swift
@@ -42,6 +42,7 @@ class UserViewController: UITableViewController {
             
             for (index: String, subJson: JSON) in json["contents"] {
                 var user: User = User(
+                    id: subJson["id"].int!,
                     name: subJson["name"].string!,
                     icon: NSURL(string: "")!
                 )
@@ -70,7 +71,14 @@ class UserViewController: UITableViewController {
         let user = self.users[indexPath.row] as User
         cell.userName.text = user.name
         cell.userIcon.imageView?.sd_setImageWithURL(user.icon)
+        cell.tag = user.id
         
         return cell
+    }
+
+    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject!) {
+        var profileView = segue.destinationViewController as! ProfileViewController
+
+        profileView._userId = 1
     }
 }

--- a/Kakico/Classes/Controllers/UserViewController.swift
+++ b/Kakico/Classes/Controllers/UserViewController.swift
@@ -5,8 +5,6 @@ import SwiftyJSON
 class UserViewController: UITableViewController {
     // MARK: - Properties
     var users = UserDataManager()
-
-    var selectedRow: Int?
     var _listType = ""
     
     // MARK: - View Events

--- a/Kakico/Classes/Models/Micropost.swift
+++ b/Kakico/Classes/Models/Micropost.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 struct Micropost {
-    var content: String, picture: NSURL?
+    var content: String, picture: NSURL?, user_id: Int
 }
 
 class MicropostDataManager: NSObject {

--- a/Kakico/Classes/Models/Router.swift
+++ b/Kakico/Classes/Models/Router.swift
@@ -11,6 +11,7 @@ enum Router: URLRequestConvertible {
     case GetFollowing(userId: Int)
     case PostUser(params: Dictionary<String, String>)
     case PostSession(params: Dictionary<String, String>)
+    case GetMicroposts(userId: Int)
     case PostMicropost(params: Dictionary<String, String>)
     
     var method: Alamofire.Method {
@@ -21,8 +22,9 @@ enum Router: URLRequestConvertible {
         case .GetFollowers: return .GET
         case .GetFollowing: return .GET
         case .PostUser: return .POST
-        case .PostMicropost: return .POST
         case .PostSession: return .POST
+        case .GetMicroposts: return .GET
+        case .PostMicropost: return .POST
         }
     }
     
@@ -34,8 +36,9 @@ enum Router: URLRequestConvertible {
         case .GetFollowers(let userId): return "/api/users/\(userId)/followers"
         case .GetFollowing(let userId): return "/api/users/\(userId)/following"
         case .PostUser: return "/api/users"
-        case .PostMicropost: return "/api/microposts/post"
         case .PostSession: return "api/sessions"
+        case .GetMicroposts(let userId): return "/api/users/\(userId)/microposts"
+        case .PostMicropost: return "/api/microposts/post"
         }
     }
     

--- a/Kakico/Classes/Models/User.swift
+++ b/Kakico/Classes/Models/User.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 struct User {
-    var name: String, icon: NSURL
+    var id: Int, name: String, icon: NSURL
 }
 
 class UserDataManager: NSObject {

--- a/Kakico/Classes/Storyboards/Main.storyboard
+++ b/Kakico/Classes/Storyboards/Main.storyboard
@@ -955,10 +955,10 @@
             </objects>
             <point key="canvasLocation" x="943.5" y="37"/>
         </scene>
-        <!--Profile View Controller-->
+        <!--Profile Header View Controller-->
         <scene sceneID="3hu-jO-D2h">
             <objects>
-                <viewController automaticallyAdjustsScrollViewInsets="NO" id="4rZ-fU-Zsn" customClass="ProfileViewController" customModule="Kakico" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController automaticallyAdjustsScrollViewInsets="NO" id="4rZ-fU-Zsn" customClass="ProfileHeaderViewController" customModule="Kakico" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="D39-Jq-Nmz"/>
                         <viewControllerLayoutGuide type="bottom" id="DtF-pd-UMv"/>
@@ -1293,11 +1293,11 @@
                     </view>
                     <toolbarItems/>
                     <connections>
-                        <outlet property="followerCount" destination="gNc-ur-DTs" id="6Yd-mR-k8k"/>
-                        <outlet property="followingCount" destination="FLb-Ac-Zau" id="SRq-05-JDt"/>
-                        <outlet property="nameLabel" destination="JQb-NA-4rz" id="UcA-Co-Rll"/>
-                        <outlet property="postCount" destination="XxY-A2-tRP" id="cNm-dC-qsV"/>
-                        <outlet property="userIcon" destination="L3e-Wl-OWc" id="tJG-o2-9Pu"/>
+                        <outlet property="followerCount" destination="gNc-ur-DTs" id="WYb-cR-6hr"/>
+                        <outlet property="followingCount" destination="FLb-Ac-Zau" id="cHT-xb-H1x"/>
+                        <outlet property="nameLabel" destination="JQb-NA-4rz" id="JHv-x0-BxY"/>
+                        <outlet property="postCount" destination="XxY-A2-tRP" id="9Vk-9x-EX1"/>
+                        <outlet property="userIcon" destination="L3e-Wl-OWc" id="WZH-1m-gWz"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="gnh-Ze-oxz" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1553,7 +1553,7 @@
         <!--Profile-->
         <scene sceneID="cpi-Lj-QyF">
             <objects>
-                <tableViewController id="Y87-VY-49y" customClass="FeedViewController" customModule="Kakico" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="Y87-VY-49y" customClass="ProfileViewController" customModule="Kakico" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="Rig-xa-LSt">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1739,6 +1739,9 @@
                         </connections>
                     </tableView>
                     <navigationItem key="navigationItem" title="Profile" id="ft7-oW-6FE"/>
+                    <connections>
+                        <outlet property="header" destination="waq-l5-QbF" id="8N7-br-LCX"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="nV9-Mb-DI2" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Kakico/Classes/Storyboards/Main.storyboard
+++ b/Kakico/Classes/Storyboards/Main.storyboard
@@ -920,7 +920,7 @@
                                 <connections>
                                     <outlet property="userIcon" destination="306-To-mFN" id="lX1-iS-JhT"/>
                                     <outlet property="userName" destination="p2h-WL-bd7" id="OBW-bX-A64"/>
-                                    <segue destination="Y87-VY-49y" kind="show" identifier="ProfileView" id="6dy-dw-HtE"/>
+                                    <segue destination="Y87-VY-49y" kind="show" identifier="ProfileView" id="fEa-qq-PJQ"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>

--- a/Kakico/Classes/Storyboards/Main.storyboard
+++ b/Kakico/Classes/Storyboards/Main.storyboard
@@ -920,7 +920,7 @@
                                 <connections>
                                     <outlet property="userIcon" destination="306-To-mFN" id="lX1-iS-JhT"/>
                                     <outlet property="userName" destination="p2h-WL-bd7" id="OBW-bX-A64"/>
-                                    <segue destination="Y87-VY-49y" kind="show" id="t9R-Wy-UH5"/>
+                                    <segue destination="Y87-VY-49y" kind="show" identifier="ProfileView" id="t9R-Wy-UH5"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>

--- a/Kakico/Classes/Storyboards/Main.storyboard
+++ b/Kakico/Classes/Storyboards/Main.storyboard
@@ -920,7 +920,7 @@
                                 <connections>
                                     <outlet property="userIcon" destination="306-To-mFN" id="lX1-iS-JhT"/>
                                     <outlet property="userName" destination="p2h-WL-bd7" id="OBW-bX-A64"/>
-                                    <segue destination="Y87-VY-49y" kind="show" identifier="ProfileView" id="fEa-qq-PJQ"/>
+                                    <segue destination="Y87-VY-49y" kind="show" id="t9R-Wy-UH5"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>

--- a/Kakico/Classes/Storyboards/Main.storyboard
+++ b/Kakico/Classes/Storyboards/Main.storyboard
@@ -876,9 +876,6 @@
                                                     <include reference="Cmr-aj-zM0"/>
                                                 </mask>
                                             </variation>
-                                            <connections>
-                                                <segue destination="Y87-VY-49y" kind="show" id="PHi-F4-VMw"/>
-                                            </connections>
                                         </button>
                                     </subviews>
                                     <constraints>
@@ -923,6 +920,7 @@
                                 <connections>
                                     <outlet property="userIcon" destination="306-To-mFN" id="lX1-iS-JhT"/>
                                     <outlet property="userName" destination="p2h-WL-bd7" id="OBW-bX-A64"/>
+                                    <segue destination="Y87-VY-49y" kind="show" identifier="ProfileView" id="6dy-dw-HtE"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>

--- a/Kakico/Classes/Storyboards/Main.storyboard
+++ b/Kakico/Classes/Storyboards/Main.storyboard
@@ -1560,7 +1560,7 @@
                             <rect key="frame" x="0.0" y="64" width="600" height="180"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <connections>
-                                <segue destination="4rZ-fU-Zsn" kind="embed" id="BQD-C8-vJZ"/>
+                                <segue destination="4rZ-fU-Zsn" kind="embed" identifier="ProfileHeaderView" id="BQD-C8-vJZ"/>
                             </connections>
                         </containerView>
                         <prototypes>


### PR DESCRIPTION
@orzup @alotofwe 

元issue: #60 の続き。
~~Feedに表示されているポストから、そのポストしたユーザのprofileに遷移できるようにします。~~
また、profileにはそのユーザの全ポストも表示するようにします。
遷移元が増えますが、基本どちらから遷移してきたとしても特定のユーザのprofileが表示されます。
### merge条件
- [x] @orzup or @alotofwe  がシュミュレータで動作確認をすること
  - [ ] ~~Feed > Profile と遷移できること~~
  - [x] Config > All(or followers, following) > ユーザリスト > Profile と遷移できること
  - [x] ポストしたユーザのプロフィールが表示されること
    - 全ポスト
- [x] TravisCIがグリーンであること
