### PR TITLE
Infinite Scrollを，paginateありのAPIを使用している画面全てに実装

### DIFF
--- a/Kakico/Classes/Controllers/FeedViewController.swift
+++ b/Kakico/Classes/Controllers/FeedViewController.swift
@@ -14,8 +14,8 @@ class FeedViewController: MicropostViewController {
         // Add infinite scroll handler
         tableView.addInfiniteScrollWithHandler { (scrollView) -> Void in
             let tableView = scrollView as! UITableView
-            if (self.microposts.next_page != nil) {
-                self.request(self.microposts.next_page!)
+            if (self.microposts.nextPage != nil) {
+                self.request(self.microposts.nextPage!)
             }
             tableView.finishInfiniteScroll()
         }
@@ -61,7 +61,7 @@ class FeedViewController: MicropostViewController {
                     self.microposts.set(micropost)
                 }
                 
-                self.microposts.next_page = json["next_page"].intValue
+                self.microposts.nextPage = json["next_page"].intValue
                 
                 dispatch_async(dispatch_get_main_queue(), {
                     self.tableView.reloadData()

--- a/Kakico/Classes/Controllers/ProfileViewController.swift
+++ b/Kakico/Classes/Controllers/ProfileViewController.swift
@@ -16,8 +16,8 @@ class ProfileViewController: MicropostViewController {
         tableView.addInfiniteScrollWithHandler { (scrollView) -> Void in
             let tableView = scrollView as! UITableView
             
-            if (self.microposts.next_page != nil) {
-                self.request(super._selectUserId, page: self.microposts.next_page!)
+            if (self.microposts.nextPage != nil) {
+                self.request(super._selectUserId, page: self.microposts.nextPage!)
             }
             
             self.tableView.reloadData()
@@ -60,7 +60,7 @@ class ProfileViewController: MicropostViewController {
                     self.microposts.set(micropost)
                 }
 
-                self.microposts.next_page = json["next_page"].intValue
+                self.microposts.nextPage = json["next_page"].intValue
 
                 dispatch_async(dispatch_get_main_queue(), {
                     self.tableView.reloadData()

--- a/Kakico/Classes/Controllers/ProfileViewController.swift
+++ b/Kakico/Classes/Controllers/ProfileViewController.swift
@@ -79,9 +79,4 @@ class ProfileViewController: MicropostViewController {
             headerView._selectUserId = self._selectUserId
         }
     }
-
-    // MARK: - Navigation
-    //@IBAction func unwindToMicropostList(sender: UIStoryboardSegue) {
-    //    request(1)
-    //}
 }

--- a/Kakico/Classes/Controllers/UserViewController.swift
+++ b/Kakico/Classes/Controllers/UserViewController.swift
@@ -18,8 +18,8 @@ class UserViewController: UITableViewController {
         tableView.addInfiniteScrollWithHandler { (scrollView) -> Void in
             let tableView = scrollView as! UITableView
             
-            if (self.users.next_page != nil) {
-                self.request(self._listType, page: self.users.next_page!)
+            if (self.users.nextPage != nil) {
+                self.request(self._listType, page: self.users.nextPage!)
             }
             
             self.tableView.reloadData()
@@ -74,7 +74,7 @@ class UserViewController: UITableViewController {
                 self.users.set(user)
             }
 
-            self.users.next_page = json["next_page"].intValue
+            self.users.nextPage = json["next_page"].intValue
 
             dispatch_async(dispatch_get_main_queue(), {
                 self.tableView!.reloadData()

--- a/Kakico/Classes/Controllers/UserViewController.swift
+++ b/Kakico/Classes/Controllers/UserViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 import Alamofire
 import SwiftyJSON
 import KeychainAccess
+import UIScrollView_InfiniteScroll
 
 class UserViewController: UITableViewController {
     // MARK: - Properties
@@ -11,10 +12,23 @@ class UserViewController: UITableViewController {
     // MARK: - View Events
     override func viewDidLoad() {
         super.viewDidLoad()
-        request(_listType)
+        request(_listType, page: 1)
+
+        // Add infinite scroll handler
+        tableView.addInfiniteScrollWithHandler { (scrollView) -> Void in
+            let tableView = scrollView as! UITableView
+            
+            if (self.users.next_page != nil) {
+                self.request(self._listType, page: self.users.next_page!)
+            }
+            
+            self.tableView.reloadData()
+            
+            tableView.finishInfiniteScroll()
+        }
     }
     
-    func request(listType: String) {
+    func request(listType: String, page: Int) {
         self.navigationItem.title = listType
 
         var userId : Int = 1
@@ -23,17 +37,21 @@ class UserViewController: UITableViewController {
             userId = id.toInt()!
         }
         
+        let params = [
+            "page": String(page)
+        ]
+
         switch listType {
         case "All":
-            Alamofire.request(Router.GetAllUsers()).responseJSON { (request, response, data, error) -> Void in
+            Alamofire.request(Router.GetAllUsers(params: params)).responseJSON { (request, response, data, error) -> Void in
                 self.setUserList(data)
             }
         case "Followers":
-            Alamofire.request(Router.GetFollowers(userId: userId)).responseJSON { (request, response, data, error) -> Void in
+            Alamofire.request(Router.GetFollowers(userId: userId, params: params)).responseJSON { (request, response, data, error) -> Void in
                 self.setUserList(data)
             }
         case "Following":
-            Alamofire.request(Router.GetFollowing(userId: userId)).responseJSON { (request, response, data, error) -> Void in
+            Alamofire.request(Router.GetFollowing(userId: userId, params: params)).responseJSON { (request, response, data, error) -> Void in
                 self.setUserList(data)
             }
         default:
@@ -55,10 +73,13 @@ class UserViewController: UITableViewController {
                 )
                 self.users.set(user)
             }
-            
+
+            self.users.next_page = json["next_page"].intValue
+
             dispatch_async(dispatch_get_main_queue(), {
                 self.tableView!.reloadData()
             })
+
         }
     }
     

--- a/Kakico/Classes/Models/Micropost.swift
+++ b/Kakico/Classes/Models/Micropost.swift
@@ -11,7 +11,7 @@ struct Micropost {
 
 class MicropostDataManager: NSObject {
     var microposts: [Micropost]
-    var next_page: Int?
+    var nextPage: Int?
     
     override init() {
         self.microposts = []

--- a/Kakico/Classes/Models/Router.swift
+++ b/Kakico/Classes/Models/Router.swift
@@ -2,8 +2,7 @@ import Alamofire
 import KeychainAccess
 
 enum Router: URLRequestConvertible {
-    //static let baseURLString = "https://157.7.190.148"
-    static let baseURLString = "http://localhost:3000"
+    static let baseURLString = "https://157.7.190.148"
 
     case GetUser(userId: Int)
 

--- a/Kakico/Classes/Models/Router.swift
+++ b/Kakico/Classes/Models/Router.swift
@@ -2,42 +2,49 @@ import Alamofire
 import KeychainAccess
 
 enum Router: URLRequestConvertible {
-    static let baseURLString = "https://157.7.190.148"
+    //static let baseURLString = "https://157.7.190.148"
+    static let baseURLString = "http://localhost:3000"
+
+    case GetUser(userId: Int)
 
     case GetFeed(params: Dictionary<String, String>)
-    case GetAllUsers()
-    case GetUser(userId: Int)
-    case GetFollowers(userId: Int)
-    case GetFollowing(userId: Int)
+    case GetAllUsers(params: Dictionary<String, String>)
+
+    case GetFollowers(userId: Int, params: Dictionary<String, String>)
+    case GetFollowing(userId: Int, params: Dictionary<String, String>)
+    case GetMicroposts(userId: Int, params: Dictionary<String, String>)
+
     case PostUser(params: Dictionary<String, String>)
     case PostSession(params: Dictionary<String, String>)
     case PostMicropost()
-    case GetMicroposts(userId: Int)
-    
+
     var method: Alamofire.Method {
         switch self {
-        case .GetFeed: return .GET
         case .GetUser: return .GET
+        case .GetFeed: return .GET
         case .GetAllUsers: return .GET
         case .GetFollowers: return .GET
         case .GetFollowing: return .GET
+        case .GetMicroposts: return .GET
         case .PostUser: return .POST
         case .PostSession: return .POST
-        case .GetMicroposts: return .GET
         case .PostMicropost: return .POST
         }
     }
     
     var path: String {
         switch self {
-        case .GetFeed(let page): return "/api/users/feed"
         case .GetUser(let userId): return "/api/users/\(userId)"
+
+        case .GetFeed(let page): return "/api/users/feed"
         case .GetAllUsers: return "/api/users"
-        case .GetFollowers(let userId): return "/api/users/\(userId)/followers"
-        case .GetFollowing(let userId): return "/api/users/\(userId)/following"
+
+        case .GetFollowers(let userId, let params): return "/api/users/\(userId)/followers"
+        case .GetFollowing(let userId, let params): return "/api/users/\(userId)/following"
+        case .GetMicroposts(let userId, let params): return "/api/users/\(userId)/microposts"
+
         case .PostUser: return "/api/users"
         case .PostSession: return "api/sessions"
-        case .GetMicroposts(let userId): return "/api/users/\(userId)/microposts"
         case .PostMicropost: return "/api/microposts/post"
         }
     }
@@ -59,8 +66,16 @@ enum Router: URLRequestConvertible {
             return Alamofire.ParameterEncoding.JSON.encode(mutableURLRequest, parameters: parameters).0
         case .PostSession(let parameters):
             return Alamofire.ParameterEncoding.JSON.encode(mutableURLRequest, parameters: parameters).0
-            case .GetFeed(let parameters):
-                return Alamofire.ParameterEncoding.URL.encode(mutableURLRequest, parameters: parameters).0
+        case .GetFeed(let parameters):
+            return Alamofire.ParameterEncoding.URL.encode(mutableURLRequest, parameters: parameters).0
+        case .GetAllUsers(let parameters):
+            return Alamofire.ParameterEncoding.URL.encode(mutableURLRequest, parameters: parameters).0
+        case .GetFollowers(let userId, let parameters):
+            return Alamofire.ParameterEncoding.URL.encode(mutableURLRequest, parameters: parameters).0
+        case .GetFollowing(let userId, let parameters):
+            return Alamofire.ParameterEncoding.URL.encode(mutableURLRequest, parameters: parameters).0
+        case .GetMicroposts(let userId, let parameters):
+            return Alamofire.ParameterEncoding.URL.encode(mutableURLRequest, parameters: parameters).0
         default:
             return mutableURLRequest
         }

--- a/Kakico/Classes/Models/User.swift
+++ b/Kakico/Classes/Models/User.swift
@@ -6,6 +6,7 @@ struct User {
 
 class UserDataManager: NSObject {
     var users: [User]
+    var next_page: Int?
     
     override init() {
         self.users = []

--- a/Kakico/Classes/Models/User.swift
+++ b/Kakico/Classes/Models/User.swift
@@ -6,7 +6,7 @@ struct User {
 
 class UserDataManager: NSObject {
     var users: [User]
-    var next_page: Int?
+    var nextPage: Int?
     
     override init() {
         self.users = []


### PR DESCRIPTION
- All Users
- Followers
- Following
- Profile

に，Feedと同じようにInfinite Scrollを実装していきます．
# Close条件
- [x] Passed CI
- [x] 1 LGTM
# チェック方法

現在のNyahのほうではpaginateするほどユーザがいないため，  
一時的にlocalhost:3000を利用してください．
1. localhost:300をbaseURLに使うよう，Routerを一時的に変更
2. bundle exec rails s
3. mobile app側にて適当なユーザでログイン
   (example@railstutorial.orgだと友達が多く，フォロー/フォロワーのpaginateも動くかと思います)
4. All Usersを一番下までスクロールし，読み込まれることを確認する
5. Followersを一番下までスクロールし，読み込まれることを確認する
6. Followingを一番下までスクロールし，読み込まれることを確認する
7. ProfileのMicroposts一覧を一番下までスクロールし，読み込まれることを確認する
8. RouterのbaseURLをNyahに戻す
