### PR TITLE
時間が消えないようにAutoLayoutを修正

### DIFF
--- a/Kakico/Classes/Storyboards/Main.storyboard
+++ b/Kakico/Classes/Storyboards/Main.storyboard
@@ -25,7 +25,7 @@
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NwP-ri-1gG" userLabel="User Name">
                                             <rect key="frame" x="0.0" y="-21" width="42" height="21"/>
                                             <constraints>
-                                                <constraint firstAttribute="width" constant="220" id="5mH-00-M1F"/>
+                                                <constraint firstAttribute="width" constant="290" placeholder="YES" id="auW-NC-Q0B"/>
                                                 <constraint firstAttribute="height" constant="15" id="sSU-GR-l9l"/>
                                             </constraints>
                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
@@ -33,18 +33,18 @@
                                             <nil key="highlightedColor"/>
                                             <variation key="default">
                                                 <mask key="constraints">
-                                                    <exclude reference="5mH-00-M1F"/>
+                                                    <exclude reference="auW-NC-Q0B"/>
                                                     <exclude reference="sSU-GR-l9l"/>
                                                 </mask>
                                             </variation>
                                             <variation key="widthClass=compact">
                                                 <mask key="constraints">
-                                                    <include reference="5mH-00-M1F"/>
+                                                    <include reference="auW-NC-Q0B"/>
                                                     <include reference="sSU-GR-l9l"/>
                                                 </mask>
                                             </variation>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="5分前" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f2B-Ob-xQm" userLabel="Time">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="5分前" textAlignment="right" lineBreakMode="clip" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f2B-Ob-xQm" userLabel="Time">
                                             <rect key="frame" x="0.0" y="-21" width="42" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -98,20 +98,18 @@
                                             <variation key="widthClass=compact" constant="0.0"/>
                                         </constraint>
                                         <constraint firstItem="f2B-Ob-xQm" firstAttribute="top" secondItem="NwP-ri-1gG" secondAttribute="top" id="C1Q-4L-qUB"/>
-                                        <constraint firstItem="NwP-ri-1gG" firstAttribute="leading" secondItem="NE1-O0-oeN" secondAttribute="trailing" constant="8" id="OQd-bk-Cmt"/>
                                         <constraint firstItem="mGM-8S-zvL" firstAttribute="leading" secondItem="NE1-O0-oeN" secondAttribute="trailing" constant="8" id="Pko-C3-LoQ"/>
                                         <constraint firstItem="f2B-Ob-xQm" firstAttribute="leading" secondItem="NwP-ri-1gG" secondAttribute="trailing" constant="4" id="QSe-ar-fHc"/>
                                         <constraint firstItem="mGM-8S-zvL" firstAttribute="top" secondItem="f2B-Ob-xQm" secondAttribute="bottom" constant="8" id="SSS-7a-uU7"/>
                                         <constraint firstItem="NE1-O0-oeN" firstAttribute="leading" secondItem="Ywk-YM-BeB" secondAttribute="leadingMargin" id="TLc-a3-dmx"/>
+                                        <constraint firstItem="f2B-Ob-xQm" firstAttribute="height" secondItem="NwP-ri-1gG" secondAttribute="height" id="TtK-yF-WoQ"/>
                                         <constraint firstItem="yzR-f9-U4L" firstAttribute="top" secondItem="mGM-8S-zvL" secondAttribute="bottom" constant="8" id="Uik-dO-iUs"/>
                                         <constraint firstItem="f2B-Ob-xQm" firstAttribute="trailing" secondItem="mGM-8S-zvL" secondAttribute="trailing" id="V8g-8B-wto"/>
-                                        <constraint firstItem="f2B-Ob-xQm" firstAttribute="top" secondItem="Ywk-YM-BeB" secondAttribute="topMargin" constant="8" id="Wbt-Cb-fSV"/>
                                         <constraint firstAttribute="bottomMargin" secondItem="yzR-f9-U4L" secondAttribute="bottom" id="k8A-rP-eZA"/>
                                         <constraint firstItem="NwP-ri-1gG" firstAttribute="leading" secondItem="NE1-O0-oeN" secondAttribute="trailing" constant="4" id="mhV-p1-6Ub"/>
                                         <constraint firstItem="yzR-f9-U4L" firstAttribute="trailing" secondItem="mGM-8S-zvL" secondAttribute="trailing" id="nvm-J8-uOl"/>
                                         <constraint firstItem="NE1-O0-oeN" firstAttribute="top" secondItem="Ywk-YM-BeB" secondAttribute="topMargin" id="wJ5-MD-szh"/>
                                         <constraint firstAttribute="trailingMargin" secondItem="mGM-8S-zvL" secondAttribute="trailing" id="wg9-Y1-bpt"/>
-                                        <constraint firstItem="NE1-O0-oeN" firstAttribute="leading" secondItem="Ywk-YM-BeB" secondAttribute="leadingMargin" constant="8" id="xfe-Sa-DXf"/>
                                         <constraint firstItem="yzR-f9-U4L" firstAttribute="leading" secondItem="mGM-8S-zvL" secondAttribute="leading" id="z2e-Ub-ACK"/>
                                     </constraints>
                                     <variation key="default">
@@ -123,24 +121,22 @@
                                             <exclude reference="mGM-8S-zvL"/>
                                         </mask>
                                         <mask key="constraints">
+                                            <exclude reference="TLc-a3-dmx"/>
+                                            <exclude reference="wJ5-MD-szh"/>
                                             <exclude reference="2Da-ul-8KP"/>
-                                            <exclude reference="OQd-bk-Cmt"/>
                                             <exclude reference="mhV-p1-6Ub"/>
-                                            <exclude reference="C1Q-4L-qUB"/>
-                                            <exclude reference="QSe-ar-fHc"/>
-                                            <exclude reference="V8g-8B-wto"/>
-                                            <exclude reference="Wbt-Cb-fSV"/>
                                             <exclude reference="Pko-C3-LoQ"/>
                                             <exclude reference="SSS-7a-uU7"/>
                                             <exclude reference="wg9-Y1-bpt"/>
-                                            <exclude reference="TLc-a3-dmx"/>
-                                            <exclude reference="wJ5-MD-szh"/>
-                                            <exclude reference="xfe-Sa-DXf"/>
                                             <exclude reference="5UD-ft-122"/>
                                             <exclude reference="Uik-dO-iUs"/>
                                             <exclude reference="k8A-rP-eZA"/>
                                             <exclude reference="nvm-J8-uOl"/>
                                             <exclude reference="z2e-Ub-ACK"/>
+                                            <exclude reference="C1Q-4L-qUB"/>
+                                            <exclude reference="QSe-ar-fHc"/>
+                                            <exclude reference="TtK-yF-WoQ"/>
+                                            <exclude reference="V8g-8B-wto"/>
                                         </mask>
                                     </variation>
                                     <variation key="widthClass=compact">
@@ -152,24 +148,22 @@
                                             <include reference="mGM-8S-zvL"/>
                                         </mask>
                                         <mask key="constraints">
+                                            <include reference="TLc-a3-dmx"/>
+                                            <include reference="wJ5-MD-szh"/>
                                             <include reference="2Da-ul-8KP"/>
-                                            <exclude reference="OQd-bk-Cmt"/>
                                             <include reference="mhV-p1-6Ub"/>
-                                            <include reference="C1Q-4L-qUB"/>
-                                            <include reference="QSe-ar-fHc"/>
-                                            <include reference="V8g-8B-wto"/>
-                                            <exclude reference="Wbt-Cb-fSV"/>
                                             <include reference="Pko-C3-LoQ"/>
                                             <include reference="SSS-7a-uU7"/>
                                             <include reference="wg9-Y1-bpt"/>
-                                            <include reference="TLc-a3-dmx"/>
-                                            <include reference="wJ5-MD-szh"/>
-                                            <exclude reference="xfe-Sa-DXf"/>
                                             <include reference="5UD-ft-122"/>
                                             <include reference="Uik-dO-iUs"/>
                                             <include reference="k8A-rP-eZA"/>
                                             <include reference="nvm-J8-uOl"/>
                                             <include reference="z2e-Ub-ACK"/>
+                                            <include reference="C1Q-4L-qUB"/>
+                                            <include reference="QSe-ar-fHc"/>
+                                            <include reference="TtK-yF-WoQ"/>
+                                            <include reference="V8g-8B-wto"/>
                                         </mask>
                                     </variation>
                                 </tableViewCellContentView>
@@ -1053,12 +1047,12 @@
                                             <exclude reference="MkW-h6-wnG"/>
                                         </mask>
                                         <mask key="constraints">
-                                            <exclude reference="EHN-Fv-cc3"/>
-                                            <exclude reference="Mpm-mz-pMS"/>
                                             <exclude reference="M5Q-jc-fUA"/>
                                             <exclude reference="jQB-Ah-dtH"/>
                                             <exclude reference="6Fk-D7-GO5"/>
                                             <exclude reference="oKU-gT-uRZ"/>
+                                            <exclude reference="EHN-Fv-cc3"/>
+                                            <exclude reference="Mpm-mz-pMS"/>
                                         </mask>
                                     </variation>
                                     <variation key="widthClass=compact">
@@ -1068,12 +1062,12 @@
                                             <include reference="MkW-h6-wnG"/>
                                         </mask>
                                         <mask key="constraints">
-                                            <include reference="EHN-Fv-cc3"/>
-                                            <include reference="Mpm-mz-pMS"/>
                                             <include reference="M5Q-jc-fUA"/>
                                             <include reference="jQB-Ah-dtH"/>
                                             <include reference="6Fk-D7-GO5"/>
                                             <include reference="oKU-gT-uRZ"/>
+                                            <include reference="EHN-Fv-cc3"/>
+                                            <include reference="Mpm-mz-pMS"/>
                                         </mask>
                                     </variation>
                                 </tableViewCellContentView>


### PR DESCRIPTION
@alotofwe or @takuminnnn 

時間表示の文字列が長いと省略されてしまっていたのですがその部分を修正しました。

ちょっとわかりにくいですが、投稿してすぐFeedを見に行くと `less than ...` みたいなことになっていたのがなおっています。
