### PR TITLE
パスワードリセットができる

### DIFF
--- a/Kakico/Classes/Controllers/ForgotPasswordViewController.swift
+++ b/Kakico/Classes/Controllers/ForgotPasswordViewController.swift
@@ -19,6 +19,7 @@ class ForgotPasswordViewController: UIViewController, UITextFieldDelegate {
 
     @IBAction func unFocusTextField(sender: UITapGestureRecognizer) {
         emailTextField.resignFirstResponder()
+        submitButton.enabled = checkValidForm()
     }
 
     // MARK: - UITextFieldDelegate

--- a/Kakico/Classes/Controllers/ForgotPasswordViewController.swift
+++ b/Kakico/Classes/Controllers/ForgotPasswordViewController.swift
@@ -1,4 +1,6 @@
 import UIKit
+import Alamofire
+import SwiftyJSON
 import SVProgressHUD
 
 class ForgotPasswordViewController: UIViewController, UITextFieldDelegate {
@@ -12,7 +14,7 @@ class ForgotPasswordViewController: UIViewController, UITextFieldDelegate {
 
     // MARK: - Actions
     @IBAction func touchSubmitButton(sender: UIButton) {
-        forgotPassword()
+        sendResetEmail(emailTextField.text)
     }
 
     @IBAction func unFocusTextField(sender: UITapGestureRecognizer) {
@@ -27,13 +29,29 @@ class ForgotPasswordViewController: UIViewController, UITextFieldDelegate {
     }
 
     // MARK: -
-    private func forgotPassword() {
+    func moveToLoginView() {
+        let loginView = self.storyboard!.instantiateViewControllerWithIdentifier("LoginViewController") as! UIViewController
+        loginView.modalTransitionStyle = UIModalTransitionStyle.CoverVertical
+        self.presentViewController(loginView, animated: true, completion: nil)
+    }
+
+    func sendResetEmail(email: String) {
+        let params = [
+            "email": email
+        ]
+
         emailTextField.resignFirstResponder()
-        SVProgressHUD.showWithStatus("", maskType: .Black)
-        if checkValidForm() {
-            SVProgressHUD.showSuccessWithStatus("", maskType: .Black)
-        } else {
-            SVProgressHUD.showErrorWithStatus("", maskType: .Black)
+        SVProgressHUD.showWithMaskType(SVProgressHUDMaskType.Black)
+
+        Alamofire.request(Router.PostPasswordResetEmail(params: params)).responseJSON { (request, response, data, error) -> Void in
+            let json = JSON(data!)
+            println(json)
+            println(json["status"])
+            if json["status"] == 200 {
+                self.moveToLoginView()
+            } else{
+                SVProgressHUD.showErrorWithStatus(json["messages"]["notice"][0].stringValue)
+            }
         }
     }
 

--- a/Kakico/Classes/Controllers/ForgotPasswordViewController.swift
+++ b/Kakico/Classes/Controllers/ForgotPasswordViewController.swift
@@ -36,12 +36,12 @@ class ForgotPasswordViewController: UIViewController, UITextFieldDelegate {
     }
 
     func sendResetEmail(email: String) {
+        emailTextField.resignFirstResponder()
+        SVProgressHUD.showWithMaskType(SVProgressHUDMaskType.Black)
+
         let params = [
             "email": email
         ]
-
-        emailTextField.resignFirstResponder()
-        SVProgressHUD.showWithMaskType(SVProgressHUDMaskType.Black)
 
         Alamofire.request(Router.PostPasswordResetEmail(params: params)).responseJSON { (request, response, data, error) -> Void in
             let json = JSON(data!)

--- a/Kakico/Classes/Controllers/ForgotPasswordViewController.swift
+++ b/Kakico/Classes/Controllers/ForgotPasswordViewController.swift
@@ -55,12 +55,7 @@ class ForgotPasswordViewController: UIViewController, UITextFieldDelegate {
         }
     }
 
-    private func checkValidEmail(email: String) -> Bool{
-        let regex = "^[\\w+\\-.]+@[a-z\\d\\-]+(\\.[a-z\\d\\-]+)*\\.[a-z]+$"
-        return NSPredicate(format: "SELF MATCHES %@", regex).evaluateWithObject(email)
-    }
-
     private func checkValidForm() -> Bool {
-        return emailTextField.hasText() && checkValidEmail(emailTextField.text)
+        return emailTextField.hasText()
     }
 }

--- a/Kakico/Classes/Controllers/ForgotPasswordViewController.swift
+++ b/Kakico/Classes/Controllers/ForgotPasswordViewController.swift
@@ -50,7 +50,7 @@ class ForgotPasswordViewController: UIViewController, UITextFieldDelegate {
             if json["status"] == 200 {
                 self.moveToLoginView()
             } else{
-                SVProgressHUD.showErrorWithStatus(json["messages"]["notice"][0].stringValue)
+                SVProgressHUD.showErrorWithStatus(json["messages"]["notice"].array!.first?.stringValue)
             }
         }
     }

--- a/Kakico/Classes/Controllers/ResetPasswordViewController.swift
+++ b/Kakico/Classes/Controllers/ResetPasswordViewController.swift
@@ -48,13 +48,13 @@ class ResetPasswordViewController: UIViewController, UITextFieldDelegate {
     }
 
     private func resetPassword(password: String, password_confirmation: String) {
+        hideKeyboard()
+        SVProgressHUD.showWithMaskType(SVProgressHUDMaskType.Black)
+
         let params = [
             "password": password,
             "password_confirmation": password_confirmation
         ]
-
-        hideKeyboard()
-        SVProgressHUD.showWithMaskType(SVProgressHUDMaskType.Black)
 
         Alamofire.request(Router.UpdatePassword(params: params)).responseJSON { (request, response, data, error) -> Void in
             let json = JSON(data!)

--- a/Kakico/Classes/Controllers/ResetPasswordViewController.swift
+++ b/Kakico/Classes/Controllers/ResetPasswordViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import Alamofire
 import SwiftyJSON
+import KeychainAccess
 import SVProgressHUD
 
 class ResetPasswordViewController: UIViewController, UITextFieldDelegate {
@@ -60,6 +61,9 @@ class ResetPasswordViewController: UIViewController, UITextFieldDelegate {
             println(json)
             println(json["status"])
             if json["status"] == 200 {
+                var keychain = Keychain(service: "nehan.Kakico")
+                keychain["userId"] = json["user_id"].stringValue
+
                 self.moveToFeedView()
             } else{
                 SVProgressHUD.showErrorWithStatus(json["messages"]["user"].dictionary!.values.first?.stringValue)

--- a/Kakico/Classes/Controllers/ResetPasswordViewController.swift
+++ b/Kakico/Classes/Controllers/ResetPasswordViewController.swift
@@ -1,9 +1,13 @@
 import UIKit
+import Alamofire
+import SwiftyJSON
 import SVProgressHUD
 
 class ResetPasswordViewController: UIViewController, UITextFieldDelegate {
     // MARK: - Properties
     @IBOutlet var textFields: [UITextField]!
+    @IBOutlet weak var passwordField: UITextField!
+    @IBOutlet weak var confirmationField: UITextField!
     @IBOutlet weak var updateButton: UIButton!
 
     // MARK: - View Events
@@ -13,7 +17,7 @@ class ResetPasswordViewController: UIViewController, UITextFieldDelegate {
 
     // MARK: - Actions
     @IBAction func touchUpdateButton(sender: UIButton) {
-        resetPassword()
+        resetPassword(passwordField.text, password_confirmation: confirmationField.text)
     }
 
     @IBAction func unFocusTextField(sender: UITapGestureRecognizer) {
@@ -36,13 +40,30 @@ class ResetPasswordViewController: UIViewController, UITextFieldDelegate {
     }
 
     // MARK: -
-    private func resetPassword() {
+    func moveToFeedView() {
+        let feedView = self.storyboard!.instantiateViewControllerWithIdentifier("FeedNavigationController") as! UIViewController
+        feedView.modalTransitionStyle = UIModalTransitionStyle.CoverVertical
+        self.presentViewController(feedView, animated: true, completion: nil)
+    }
+
+    private func resetPassword(password: String, password_confirmation: String) {
+        let params = [
+            "password": password,
+            "password_confirmation": password_confirmation
+        ]
+
         hideKeyboard()
-        SVProgressHUD.showWithStatus("", maskType: .Black)
-        if checkPresenceField() {
-            SVProgressHUD.showSuccessWithStatus("", maskType: .Black)
-        } else {
-            SVProgressHUD.showErrorWithStatus("", maskType: .Black)
+        SVProgressHUD.showWithMaskType(SVProgressHUDMaskType.Black)
+
+        Alamofire.request(Router.UpdatePassword(params: params)).responseJSON { (request, response, data, error) -> Void in
+            let json = JSON(data!)
+            println(json)
+            println(json["status"])
+            if json["status"] == 200 {
+                self.moveToFeedView()
+            } else{
+                SVProgressHUD.showErrorWithStatus(json["messages"]["user"].dictionary!.values.first?.stringValue)
+            }
         }
     }
 

--- a/Kakico/Classes/Models/Router.swift
+++ b/Kakico/Classes/Models/Router.swift
@@ -19,6 +19,9 @@ enum Router: URLRequestConvertible {
     
     case PostRelationships(followedId: Int)
     case DeleteRelationships(followedId: Int)
+
+    case PostPasswordResetEmail(params: Dictionary<String, String>)
+    case UpdatePassword(params: Dictionary<String, String>)
     
     var method: Alamofire.Method {
         switch self {
@@ -33,6 +36,8 @@ enum Router: URLRequestConvertible {
         case .PostMicropost: return .POST
         case .PostRelationships: return .POST
         case .DeleteRelationships: return .DELETE
+        case .PostPasswordResetEmail: return .POST
+        case .UpdatePassword: return .POST
         }
     }
     
@@ -52,6 +57,9 @@ enum Router: URLRequestConvertible {
         case .PostMicropost: return "/api/microposts/post"
         case .PostRelationships(let followedId): return "/api/relationships/\(followedId)"
         case .DeleteRelationships(let followedId): return "/api/relationships/\(followedId)"
+
+        case .PostPasswordResetEmail: return "/api/password_resets/create"
+        case .UpdatePassword: return "/api/password_resets/update"
         }
     }
 
@@ -82,6 +90,10 @@ enum Router: URLRequestConvertible {
             return Alamofire.ParameterEncoding.URL.encode(mutableURLRequest, parameters: parameters).0
         case .GetMicroposts(let userId, let parameters):
             return Alamofire.ParameterEncoding.URL.encode(mutableURLRequest, parameters: parameters).0
+        case .PostPasswordResetEmail(let parameters):
+            return Alamofire.ParameterEncoding.JSON.encode(mutableURLRequest, parameters: parameters).0
+        case .UpdatePassword(let parameters):
+            return Alamofire.ParameterEncoding.JSON.encode(mutableURLRequest, parameters: parameters).0
         default:
             return mutableURLRequest
         }

--- a/Kakico/Classes/Storyboards/Main.storyboard
+++ b/Kakico/Classes/Storyboards/Main.storyboard
@@ -1665,6 +1665,8 @@
                     </view>
                     <navigationItem key="navigationItem" title="Reset password" id="nHa-EP-apq"/>
                     <connections>
+                        <outlet property="confirmationField" destination="y5Y-a1-WCO" id="0Ni-oE-L8M"/>
+                        <outlet property="passwordField" destination="Dud-9d-LQj" id="QP4-9n-gw4"/>
                         <outlet property="updateButton" destination="hOj-Cf-h6b" id="IWw-8h-suu"/>
                         <outletCollection property="textFields" destination="Dud-9d-LQj" collectionClass="NSMutableArray" id="OFS-Vj-kHc"/>
                         <outletCollection property="textFields" destination="y5Y-a1-WCO" collectionClass="NSMutableArray" id="qrl-5R-4cJ"/>

--- a/Kakico/Classes/Storyboards/Main.storyboard
+++ b/Kakico/Classes/Storyboards/Main.storyboard
@@ -1693,7 +1693,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Email" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="LgQ-YN-Afq">
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Email" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="LgQ-YN-Afq">
                                 <rect key="frame" x="0.0" y="-30" width="97" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="250" id="ivo-f6-DvU"/>


### PR DESCRIPTION
@orzup @alotofwe 

画面遷移は login > forget > login > (mail) > password_reset > feed
### 使うAPI
- https://github.com/alotofwe/sample_app-1/pull/37
- https://github.com/alotofwe/sample_app-1/pull/50 (修正) 
### merge条件
- [x] @orzup or @alotofwe  が動作確認をすること
  - [x] forget画面から、アドレスを入力してリセットメールを送れること
  - [x] password_reset画面から、新たなパスワードを入力して更新できること
  - [x] パスワード更新に成功すると、Feedに遷移すること
  - [x] リセットメール送信、パスワード更新ともにAPI側のバリデーションが効いていて、正しいレスポンスが返ってくること
  - [x] パスワード更新成功時に、キーチェーンにトークンと自身のIDが保存されていること
- [x] TravisCIがグリーンであること
