### PR TITLE
ポストを投稿するときにキャンセルしたらキーボードが取り残されるのを修正

### DIFF
--- a/Kakico/Classes/Controllers/NewPostlViewController.swift
+++ b/Kakico/Classes/Controllers/NewPostlViewController.swift
@@ -36,6 +36,7 @@ class NewPostViewController: UIViewController, UITextViewDelegate, UIImagePicker
     }
 
     @IBAction func cancel(sender: UIBarButtonItem) {
+        contentField.resignFirstResponder()
         dismissViewControllerAnimated(true, completion: nil)
     }
 


### PR DESCRIPTION
ポストを投稿するときにキャンセルしたらキーボードをしまってから遷移するように変更しました！
