### PR TITLE
自動ログイン時にくしゃっとなるのを修正

### DIFF
--- a/Kakico.xcodeproj/project.pbxproj
+++ b/Kakico.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		25C861A09D9888E2811D0F06 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48953E8A0982D8CAF6A08ABF /* Pods.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		6B449CCC1BA26D1E00D25549 /* LoadViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B449CCB1BA26D1E00D25549 /* LoadViewController.swift */; };
 		6B8255FD1B8AC8BA005E2397 /* UserTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8255FC1B8AC8BA005E2397 /* UserTableViewCell.swift */; };
 		6B8256011B8ACB8D005E2397 /* UserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8256001B8ACB8D005E2397 /* UserViewController.swift */; };
 		6B8256091B8AE755005E2397 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8256081B8AE754005E2397 /* User.swift */; };
@@ -50,6 +51,7 @@
 		0B37E5E41D741F08483B9CD0 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		31D3F4020A52B9C72A4E00EE /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		48953E8A0982D8CAF6A08ABF /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6B449CCB1BA26D1E00D25549 /* LoadViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LoadViewController.swift; path = Controllers/LoadViewController.swift; sourceTree = "<group>"; };
 		6B8255FC1B8AC8BA005E2397 /* UserTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserTableViewCell.swift; path = Views/Cells/UserTableViewCell.swift; sourceTree = "<group>"; };
 		6B8256001B8ACB8D005E2397 /* UserViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserViewController.swift; path = Controllers/UserViewController.swift; sourceTree = "<group>"; };
 		6B8256081B8AE754005E2397 /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
@@ -123,6 +125,7 @@
 		6BD417041B8C0CBE0027BC14 /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				6B449CCB1BA26D1E00D25549 /* LoadViewController.swift */,
 				89878BB11B844E8C004CCD77 /* FeedViewController.swift */,
 				AB785DDD1B846EED002DA142 /* NewPostlViewController.swift */,
 				6B8256001B8ACB8D005E2397 /* UserViewController.swift */,
@@ -412,6 +415,7 @@
 				89878BB21B844E8C004CCD77 /* FeedViewController.swift in Sources */,
 				893C220D1B983F9300C006E4 /* ProfileHeaderViewController.swift in Sources */,
 				893C220B1B9835EE00C006E4 /* MicropostViewController.swift in Sources */,
+				6B449CCC1BA26D1E00D25549 /* LoadViewController.swift in Sources */,
 				6B8255FD1B8AC8BA005E2397 /* UserTableViewCell.swift in Sources */,
 				ABD628071B9FD597001762E4 /* ProfileEditViewController.swift in Sources */,
 				6BF845CB1B956BE700BDFA11 /* ForgotPasswordViewController.swift in Sources */,

--- a/Kakico/AppDelegate.swift
+++ b/Kakico/AppDelegate.swift
@@ -33,11 +33,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             return (disposition, credential)
         }
 
-        var keychain = Keychain(service: "nehan.Kakico")
-        if keychain["authToken"] != nil && keychain["userId"] != nil {
-            chooseViewController("FeedNavigationController")
-        }
-
         return true
     }
 

--- a/Kakico/Classes/Controllers/LoadViewController.swift
+++ b/Kakico/Classes/Controllers/LoadViewController.swift
@@ -1,0 +1,34 @@
+import UIKit
+import KeychainAccess
+
+class LoadViewController: UIViewController {
+    // MARK: - View Events
+    override func viewDidAppear(animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if logined() {
+            autoLogin()
+        } else {
+            login()
+        }
+    }
+
+    private func logined() -> Bool {
+        var keychain = Keychain(service: "nehan.Kakico")
+        return keychain["authToken"] != nil && keychain["userId"] != nil
+    }
+
+    private func autoLogin() {
+        showNextView("FeedNavigationController")
+    }
+
+    private func login() {
+        showNextView("LoginViewController")
+    }
+
+    private func showNextView(view: String) {
+        let viewController = self.storyboard?.instantiateViewControllerWithIdentifier(view) as! UIViewController
+        viewController.modalTransitionStyle = .CrossDissolve
+        self.presentViewController(viewController, animated: true, completion: nil)
+    }
+}

--- a/Kakico/Classes/Storyboards/Main.storyboard
+++ b/Kakico/Classes/Storyboards/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="KDD-nb-63e">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="1o7-qB-Pic">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
         <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
@@ -390,6 +390,23 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="JUC-VQ-5Z2" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-1020" y="-484"/>
+        </scene>
+        <!--Load View Controller-->
+        <scene sceneID="zNh-79-Xsd">
+            <objects>
+                <viewController storyboardIdentifier="LoadViewController" id="1o7-qB-Pic" customClass="LoadViewController" customModule="Kakico" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Wpn-cQ-KOF"/>
+                        <viewControllerLayoutGuide type="bottom" id="MWA-po-MPR"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="fgM-tv-afY">
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="oWx-hK-LEn" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-4089" y="-484"/>
         </scene>
         <!--Login View Controller-->
         <scene sceneID="MLw-rH-x4A">


### PR DESCRIPTION
@takuminnnn or @alotofwe 
AppDelegateでログイン済みかどうかを判定して初めのViewを変えていたところを
LoadViewControllerでログイン済みかどうかを判定して遷移するように修正しました。
これにより、自動ログイン時にくしゃっとなる問題がなくなりました〜！

**確認してほしいところ**
- 初回ログイン時、きちんとLogin画面に遷移すること
  - ログイン後のFeed画面でマイクロポストがくしゃっとならないこと
- 自動ログイン時、きちんとFeed画面に遷移すること
  - マイクロポストがくしゃっとならないこと
- アカウントアクティベート時のメールのURLを踏んだとき、希望の画面へ遷移すること
- パスワードリセット時、Feed画面へ遷移すること
  - マイクロポストがくしゃっとならないこと
