### PR TITLE
feed更新時にnextPageを再設定しない

### DIFF
--- a/Kakico/Classes/Controllers/MicropostViewController.swift
+++ b/Kakico/Classes/Controllers/MicropostViewController.swift
@@ -136,8 +136,6 @@ class MicropostViewController: UITableViewController, UITableViewDataSource, UIT
                 newMicroposts.append(micropost)
             }
 
-            self.microposts.nextPage = json["next_page"].intValue
-
             dispatch_async(dispatch_get_main_queue(), {
                 self.microposts.add(newMicroposts)
                 self.tableView.reloadData()


### PR DESCRIPTION
更新時にもnextPageが更新されていたので，その後に過去のFeedを取得しようとすると
ずっとpage=0が渡されていてサーバでエラーが起こっていました．
# Close条件
- [x] 1 LGTM
