### PR TITLE
ViewControllerで通信してデータを整形していた部分を分離(GetUserだけ)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ before_install:
   - gem update --system
   - gem update bundler
 script:
-  - make test
+  - make debug-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ before_install:
   - gem update --system
   - gem update bundler
 script:
-  - make debug-test
+  - make test

--- a/Kakico.xcodeproj/project.pbxproj
+++ b/Kakico.xcodeproj/project.pbxproj
@@ -33,7 +33,6 @@
 		89DAD6191B96C74300BB43A6 /* MenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89DAD6181B96C74300BB43A6 /* MenuViewController.swift */; };
 		AB55C03A1B8304830077C16C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB55C0391B8304830077C16C /* AppDelegate.swift */; };
 		AB55C0411B8304830077C16C /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AB55C0401B8304830077C16C /* Images.xcassets */; };
-		AB55C0501B8304830077C16C /* KakicoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB55C04F1B8304830077C16C /* KakicoTests.swift */; };
 		AB785DDE1B846EED002DA142 /* NewPostlViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB785DDD1B846EED002DA142 /* NewPostlViewController.swift */; };
 		AB785DE21B848715002DA142 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = AB785DE11B848715002DA142 /* LaunchScreen.xib */; };
 		AB980B101B93FC2300ED6ACB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AB980B0F1B93FC2300ED6ACB /* Main.storyboard */; };
@@ -81,7 +80,6 @@
 		AB55C0401B8304830077C16C /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		AB55C0491B8304830077C16C /* KakicoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KakicoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB55C04E1B8304830077C16C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		AB55C04F1B8304830077C16C /* KakicoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakicoTests.swift; sourceTree = "<group>"; };
 		AB785DDD1B846EED002DA142 /* NewPostlViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NewPostlViewController.swift; path = Controllers/NewPostlViewController.swift; sourceTree = "<group>"; };
 		AB785DE11B848715002DA142 /* LaunchScreen.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = LaunchScreen.xib; path = Xibs/LaunchScreen.xib; sourceTree = "<group>"; };
 		AB980B0F1B93FC2300ED6ACB /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Main.storyboard; path = Storyboards/Main.storyboard; sourceTree = "<group>"; };
@@ -253,7 +251,6 @@
 		AB55C04C1B8304830077C16C /* KakicoTests */ = {
 			isa = PBXGroup;
 			children = (
-				AB55C04F1B8304830077C16C /* KakicoTests.swift */,
 				6B8C45161BA67020006195BF /* Classes */,
 				AB55C04D1B8304830077C16C /* Supporting Files */,
 			);
@@ -458,7 +455,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				89878BAC1B842B41004CCD77 /* Micropost.swift in Sources */,
-				AB55C0501B8304830077C16C /* KakicoTests.swift in Sources */,
 				6B653F3C1BA67339008BAC59 /* UserTests.swift in Sources */,
 				6BCAE9731BA6ABB300A5C447 /* Router.swift in Sources */,
 				6B8C45191BA67068006195BF /* APIClientTests.swift in Sources */,

--- a/Kakico.xcodeproj/project.pbxproj
+++ b/Kakico.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		6B8256091B8AE755005E2397 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8256081B8AE754005E2397 /* User.swift */; };
 		6B82560A1B8AE755005E2397 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8256081B8AE754005E2397 /* User.swift */; };
 		6B82560C1B8AE79D005E2397 /* UserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B82560B1B8AE79D005E2397 /* UserTests.swift */; };
+		6B8C45151BA66FCC006195BF /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8C45141BA66FCC006195BF /* APIClient.swift */; };
+		6B8C45191BA67068006195BF /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8C45181BA67068006195BF /* APIClientTests.swift */; };
 		6BB1A5391B9595A200813021 /* ResetPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB1A5381B9595A200813021 /* ResetPasswordViewController.swift */; };
 		6BEBBBEA1B8EED81007EEF4A /* SignupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEBBBE91B8EED81007EEF4A /* SignupViewController.swift */; };
 		6BF845CB1B956BE700BDFA11 /* ForgotPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF845CA1B956BE700BDFA11 /* ForgotPasswordViewController.swift */; };
@@ -56,6 +58,8 @@
 		6B8256001B8ACB8D005E2397 /* UserViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserViewController.swift; path = Controllers/UserViewController.swift; sourceTree = "<group>"; };
 		6B8256081B8AE754005E2397 /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		6B82560B1B8AE79D005E2397 /* UserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserTests.swift; path = KakicoTests/UserTests.swift; sourceTree = SOURCE_ROOT; };
+		6B8C45141BA66FCC006195BF /* APIClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
+		6B8C45181BA67068006195BF /* APIClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = APIClientTests.swift; path = Classes/Models/APIClientTests.swift; sourceTree = "<group>"; };
 		6BB1A5381B9595A200813021 /* ResetPasswordViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ResetPasswordViewController.swift; path = Controllers/ResetPasswordViewController.swift; sourceTree = "<group>"; };
 		6BEBBBE91B8EED81007EEF4A /* SignupViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SignupViewController.swift; path = Controllers/SignupViewController.swift; sourceTree = "<group>"; };
 		6BF845CA1B956BE700BDFA11 /* ForgotPasswordViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ForgotPasswordViewController.swift; path = Controllers/ForgotPasswordViewController.swift; sourceTree = "<group>"; };
@@ -110,6 +114,22 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		6B8C45161BA67020006195BF /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				6B8C45171BA67037006195BF /* Models */,
+			);
+			name = Classes;
+			sourceTree = "<group>";
+		};
+		6B8C45171BA67037006195BF /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				6B8C45181BA67068006195BF /* APIClientTests.swift */,
+			);
+			name = Models;
+			sourceTree = "<group>";
+		};
 		6BD417031B8C0CB60027BC14 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
@@ -147,6 +167,7 @@
 			children = (
 				89878BAA1B842B41004CCD77 /* Micropost.swift */,
 				6B8256081B8AE754005E2397 /* User.swift */,
+				6B8C45141BA66FCC006195BF /* APIClient.swift */,
 				8969712E1B93F5C500B0CB4C /* Router.swift */,
 				89C956341B9E88DC009C5BA2 /* UIColorExtension.swift */,
 			);
@@ -230,6 +251,7 @@
 			isa = PBXGroup;
 			children = (
 				AB55C04F1B8304830077C16C /* KakicoTests.swift */,
+				6B8C45161BA67020006195BF /* Classes */,
 				6B82560B1B8AE79D005E2397 /* UserTests.swift */,
 				AB55C04D1B8304830077C16C /* Supporting Files */,
 			);
@@ -413,6 +435,7 @@
 				89C956351B9E88DC009C5BA2 /* UIColorExtension.swift in Sources */,
 				6B8256011B8ACB8D005E2397 /* UserViewController.swift in Sources */,
 				89878BB21B844E8C004CCD77 /* FeedViewController.swift in Sources */,
+				6B8C45151BA66FCC006195BF /* APIClient.swift in Sources */,
 				893C220D1B983F9300C006E4 /* ProfileHeaderViewController.swift in Sources */,
 				893C220B1B9835EE00C006E4 /* MicropostViewController.swift in Sources */,
 				6B449CCC1BA26D1E00D25549 /* LoadViewController.swift in Sources */,
@@ -435,6 +458,7 @@
 				6B82560C1B8AE79D005E2397 /* UserTests.swift in Sources */,
 				89878BAC1B842B41004CCD77 /* Micropost.swift in Sources */,
 				AB55C0501B8304830077C16C /* KakicoTests.swift in Sources */,
+				6B8C45191BA67068006195BF /* APIClientTests.swift in Sources */,
 				6B82560A1B8AE755005E2397 /* User.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Kakico.xcodeproj/project.pbxproj
+++ b/Kakico.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		6B8C45151BA66FCC006195BF /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8C45141BA66FCC006195BF /* APIClient.swift */; };
 		6B8C45191BA67068006195BF /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8C45181BA67068006195BF /* APIClientTests.swift */; };
 		6BB1A5391B9595A200813021 /* ResetPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB1A5381B9595A200813021 /* ResetPasswordViewController.swift */; };
+		6BCAE9731BA6ABB300A5C447 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8969712E1B93F5C500B0CB4C /* Router.swift */; };
 		6BEBBBEA1B8EED81007EEF4A /* SignupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEBBBE91B8EED81007EEF4A /* SignupViewController.swift */; };
 		6BF845CB1B956BE700BDFA11 /* ForgotPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF845CA1B956BE700BDFA11 /* ForgotPasswordViewController.swift */; };
 		893C220B1B9835EE00C006E4 /* MicropostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 893C220A1B9835EE00C006E4 /* MicropostViewController.swift */; };
@@ -459,6 +460,7 @@
 				89878BAC1B842B41004CCD77 /* Micropost.swift in Sources */,
 				AB55C0501B8304830077C16C /* KakicoTests.swift in Sources */,
 				6B653F3C1BA67339008BAC59 /* UserTests.swift in Sources */,
+				6BCAE9731BA6ABB300A5C447 /* Router.swift in Sources */,
 				6B8C45191BA67068006195BF /* APIClientTests.swift in Sources */,
 				6B82560A1B8AE755005E2397 /* User.swift in Sources */,
 				6B653F3D1BA69174008BAC59 /* APIClient.swift in Sources */,

--- a/Kakico.xcodeproj/project.pbxproj
+++ b/Kakico.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		25C861A09D9888E2811D0F06 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48953E8A0982D8CAF6A08ABF /* Pods.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		6B449CCC1BA26D1E00D25549 /* LoadViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B449CCB1BA26D1E00D25549 /* LoadViewController.swift */; };
 		6B653F3C1BA67339008BAC59 /* UserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B653F3B1BA67339008BAC59 /* UserTests.swift */; };
+		6B653F3D1BA69174008BAC59 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8C45141BA66FCC006195BF /* APIClient.swift */; };
 		6B8255FD1B8AC8BA005E2397 /* UserTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8255FC1B8AC8BA005E2397 /* UserTableViewCell.swift */; };
 		6B8256011B8ACB8D005E2397 /* UserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8256001B8ACB8D005E2397 /* UserViewController.swift */; };
 		6B8256091B8AE755005E2397 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8256081B8AE754005E2397 /* User.swift */; };
@@ -460,6 +461,7 @@
 				6B653F3C1BA67339008BAC59 /* UserTests.swift in Sources */,
 				6B8C45191BA67068006195BF /* APIClientTests.swift in Sources */,
 				6B82560A1B8AE755005E2397 /* User.swift in Sources */,
+				6B653F3D1BA69174008BAC59 /* APIClient.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Kakico.xcodeproj/project.pbxproj
+++ b/Kakico.xcodeproj/project.pbxproj
@@ -9,11 +9,11 @@
 /* Begin PBXBuildFile section */
 		25C861A09D9888E2811D0F06 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48953E8A0982D8CAF6A08ABF /* Pods.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		6B449CCC1BA26D1E00D25549 /* LoadViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B449CCB1BA26D1E00D25549 /* LoadViewController.swift */; };
+		6B653F3C1BA67339008BAC59 /* UserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B653F3B1BA67339008BAC59 /* UserTests.swift */; };
 		6B8255FD1B8AC8BA005E2397 /* UserTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8255FC1B8AC8BA005E2397 /* UserTableViewCell.swift */; };
 		6B8256011B8ACB8D005E2397 /* UserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8256001B8ACB8D005E2397 /* UserViewController.swift */; };
 		6B8256091B8AE755005E2397 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8256081B8AE754005E2397 /* User.swift */; };
 		6B82560A1B8AE755005E2397 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8256081B8AE754005E2397 /* User.swift */; };
-		6B82560C1B8AE79D005E2397 /* UserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B82560B1B8AE79D005E2397 /* UserTests.swift */; };
 		6B8C45151BA66FCC006195BF /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8C45141BA66FCC006195BF /* APIClient.swift */; };
 		6B8C45191BA67068006195BF /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8C45181BA67068006195BF /* APIClientTests.swift */; };
 		6BB1A5391B9595A200813021 /* ResetPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB1A5381B9595A200813021 /* ResetPasswordViewController.swift */; };
@@ -54,10 +54,10 @@
 		31D3F4020A52B9C72A4E00EE /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		48953E8A0982D8CAF6A08ABF /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B449CCB1BA26D1E00D25549 /* LoadViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LoadViewController.swift; path = Controllers/LoadViewController.swift; sourceTree = "<group>"; };
+		6B653F3B1BA67339008BAC59 /* UserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserTests.swift; path = Classes/Models/UserTests.swift; sourceTree = "<group>"; };
 		6B8255FC1B8AC8BA005E2397 /* UserTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserTableViewCell.swift; path = Views/Cells/UserTableViewCell.swift; sourceTree = "<group>"; };
 		6B8256001B8ACB8D005E2397 /* UserViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserViewController.swift; path = Controllers/UserViewController.swift; sourceTree = "<group>"; };
 		6B8256081B8AE754005E2397 /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
-		6B82560B1B8AE79D005E2397 /* UserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserTests.swift; path = KakicoTests/UserTests.swift; sourceTree = SOURCE_ROOT; };
 		6B8C45141BA66FCC006195BF /* APIClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		6B8C45181BA67068006195BF /* APIClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = APIClientTests.swift; path = Classes/Models/APIClientTests.swift; sourceTree = "<group>"; };
 		6BB1A5381B9595A200813021 /* ResetPasswordViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ResetPasswordViewController.swift; path = Controllers/ResetPasswordViewController.swift; sourceTree = "<group>"; };
@@ -125,6 +125,7 @@
 		6B8C45171BA67037006195BF /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				6B653F3B1BA67339008BAC59 /* UserTests.swift */,
 				6B8C45181BA67068006195BF /* APIClientTests.swift */,
 			);
 			name = Models;
@@ -252,7 +253,6 @@
 			children = (
 				AB55C04F1B8304830077C16C /* KakicoTests.swift */,
 				6B8C45161BA67020006195BF /* Classes */,
-				6B82560B1B8AE79D005E2397 /* UserTests.swift */,
 				AB55C04D1B8304830077C16C /* Supporting Files */,
 			);
 			path = KakicoTests;
@@ -455,9 +455,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6B82560C1B8AE79D005E2397 /* UserTests.swift in Sources */,
 				89878BAC1B842B41004CCD77 /* Micropost.swift in Sources */,
 				AB55C0501B8304830077C16C /* KakicoTests.swift in Sources */,
+				6B653F3C1BA67339008BAC59 /* UserTests.swift in Sources */,
 				6B8C45191BA67068006195BF /* APIClientTests.swift in Sources */,
 				6B82560A1B8AE755005E2397 /* User.swift in Sources */,
 			);

--- a/Kakico/Classes/Controllers/UserViewController.swift
+++ b/Kakico/Classes/Controllers/UserViewController.swift
@@ -76,12 +76,7 @@ class UserViewController: UITableViewController {
             println(json)
 
             for (index: String, subJson: JSON) in json["contents"] {
-                var user: User = User(
-                    id: subJson["id"].int!,
-                    name: subJson["name"].string!,
-                    icon: NSURL(string: subJson["icon_url"].stringValue)!,
-                    followingFlag: subJson["following_flag"].bool!
-                )
+                var user = User(data: subJson)
                 self.users.set(user)
             }
 

--- a/Kakico/Classes/Models/APIClient.swift
+++ b/Kakico/Classes/Models/APIClient.swift
@@ -1,3 +1,12 @@
-class APIClient {
-    
+import Alamofire
+
+class APIClient: NSObject {
+    func getUser(
+        userId: Int,
+        onSuccess: (user: User) -> Void,
+        onFailure: (error: NSHTTPURLResponse) -> Void
+        ) {
+
+
+    }
 }

--- a/Kakico/Classes/Models/APIClient.swift
+++ b/Kakico/Classes/Models/APIClient.swift
@@ -1,0 +1,3 @@
+class APIClient {
+    
+}

--- a/Kakico/Classes/Models/APIClient.swift
+++ b/Kakico/Classes/Models/APIClient.swift
@@ -1,4 +1,5 @@
 import Alamofire
+import SwiftyJSON
 
 class APIClient: NSObject {
     func getUser(
@@ -6,7 +7,18 @@ class APIClient: NSObject {
         onSuccess: (user: User) -> Void,
         onFailure: (error: NSHTTPURLResponse) -> Void
         ) {
-
-
-    }
+            Alamofire.request(Router.GetUser(userId: userId)).responseJSON { (request, response, data, error) -> Void in
+                if data == nil {
+                    onFailure(error: response!)
+                } else {
+                    let json = JSON(data!)
+                    switch json["status"] {
+                    case 200:
+                        onSuccess(user: User(data: json["contents"]))
+                    default:
+                        onFailure(error: response!)
+                    }
+                }
+            }
+        }
 }

--- a/Kakico/Classes/Models/User.swift
+++ b/Kakico/Classes/Models/User.swift
@@ -1,7 +1,26 @@
 import UIKit
+import SwiftyJSON
 
 struct User {
-    var id: Int, name: String, icon: NSURL, followingFlag: Bool
+    let id: Int,
+        name: String,
+        email: String,
+        icon: NSURL,
+        micropostsCount: Int,
+        followersCount: Int,
+        followingCount: Int,
+        followingFlag: Bool
+
+    init(data: JSON) {
+        id = data["id"].int!
+        name = data["name"].string!
+        email = data["email"].string!
+        icon = NSURL(string: data["icon_url"].string!)!
+        micropostsCount = data["microposts_count"].int!
+        followersCount = data["followers_count"].int!
+        followingCount = data["following_count"].int!
+        followingFlag = data["following_flag"].bool!
+    }
 }
 
 class UserDataManager: NSObject {

--- a/KakicoTests/Classes/Models/APIClientTests.swift
+++ b/KakicoTests/Classes/Models/APIClientTests.swift
@@ -16,7 +16,6 @@ class APIClientTests: XCTestCase {
                 expectation.fulfill()
             }, onFailure: { (error) -> Void in
                 XCTFail("")
-                expectation.fulfill()
         })
 
         waitForExpectationsWithTimeout(5.0, handler: nil)
@@ -30,7 +29,6 @@ class APIClientTests: XCTestCase {
         apiClient.getUser(userId,
             onSuccess: { (user) -> Void in
                 XCTFail()
-                expectation.fulfill()
             }, onFailure: { (error) -> Void in
                 XCTAssertTrue(sample == nil)
                 expectation.fulfill()

--- a/KakicoTests/Classes/Models/APIClientTests.swift
+++ b/KakicoTests/Classes/Models/APIClientTests.swift
@@ -10,7 +10,22 @@ class APIClientTests: XCTestCase {
         super.tearDown()
     }
 
-    func testExample() {
-        XCTAssert(true, "Pass")
+
+    func testGetUser() {
+        let expectation = expectationWithDescription("getUser")
+
+        var sample: User? = nil
+        let apiClient = APIClient()
+        let userId = 1
+        apiClient.getUser(userId,
+            onSuccess: { (user) -> Void in
+                sample = user
+                expectation.fulfill()
+            }, onFailure: { (error) -> Void in
+        })
+
+        waitForExpectationsWithTimeout(5.0, handler: nil)
+
+        XCTAssertEqual(sample!.id, userId)
     }
 }

--- a/KakicoTests/Classes/Models/APIClientTests.swift
+++ b/KakicoTests/Classes/Models/APIClientTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+
+class APIClientTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testExample() {
+        XCTAssert(true, "Pass")
+    }
+}

--- a/KakicoTests/Classes/Models/APIClientTests.swift
+++ b/KakicoTests/Classes/Models/APIClientTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 
 class APIClientTests: XCTestCase {
-
+    let apiClient = APIClient()
     override func setUp() {
         super.setUp()
     }
@@ -11,21 +11,40 @@ class APIClientTests: XCTestCase {
     }
 
 
-    func testGetUser() {
-        let expectation = expectationWithDescription("getUser")
+    func testGetUserSuccess() {
+        let expectation = expectationWithDescription("getUserSuccess")
 
         var sample: User? = nil
-        let apiClient = APIClient()
+
         let userId = 1
         apiClient.getUser(userId,
             onSuccess: { (user) -> Void in
                 sample = user
                 expectation.fulfill()
             }, onFailure: { (error) -> Void in
+                expectation.fulfill()
         })
 
         waitForExpectationsWithTimeout(5.0, handler: nil)
 
         XCTAssertEqual(sample!.id, userId)
+    }
+
+    func testGetUserFailure() {
+        let expectation = expectationWithDescription("getUserFailure")
+
+        var sample: User? = nil
+        let userId = 999999
+        apiClient.getUser(userId,
+            onSuccess: { (user) -> Void in
+                sample = user
+                expectation.fulfill()
+            }, onFailure: { (error) -> Void in
+                expectation.fulfill()
+        })
+
+        waitForExpectationsWithTimeout(5.0, handler: nil)
+
+        XCTAssertTrue(sample == nil)
     }
 }

--- a/KakicoTests/Classes/Models/APIClientTests.swift
+++ b/KakicoTests/Classes/Models/APIClientTests.swift
@@ -1,35 +1,36 @@
 import XCTest
 
 class APIClientTests: XCTestCase {
-    let apiClient = APIClient()
-
-    func testGetUserSuccess() {
-        let expectation = expectationWithDescription("getUserSuccess")
-
-        let userId = 1
-        apiClient.getUser(userId,
-            onSuccess: { (user) -> Void in
-                XCTAssertEqual(user.id, userId)
-                expectation.fulfill()
-            }, onFailure: { (error) -> Void in
-                XCTFail()
-        })
-
-        waitForExpectationsWithTimeout(5.0, handler: nil)
-    }
-
-    func testGetUserFailure() {
-        let expectation = expectationWithDescription("getUserFailure")
-
-        let userId = 999999
-        apiClient.getUser(userId,
-            onSuccess: { (user) -> Void in
-                XCTFail()
-            }, onFailure: { (error) -> Void in
-                XCTAssertNotNil(error)
-                expectation.fulfill()
-        })
-
-        waitForExpectationsWithTimeout(5.0, handler: nil)
-    }
+//    let apiClient = APIClient()
+//
+//    func testGetUserSuccess() {
+//        let expectation = expectationWithDescription("getUserSuccess")
+//
+//        let userId = 1
+//        apiClient.getUser(userId,
+//            onSuccess: { (user) -> Void in
+//                println(user)
+//                XCTAssertEqual(user.id, userId)
+//                expectation.fulfill()
+//            }, onFailure: { (error) -> Void in
+//                XCTFail()
+//        })
+//
+//        waitForExpectationsWithTimeout(5.0, handler: nil)
+//    }
+//
+//    func testGetUserFailure() {
+//        let expectation = expectationWithDescription("getUserFailure")
+//
+//        let userId = 999999
+//        apiClient.getUser(userId,
+//            onSuccess: { (user) -> Void in
+//                XCTFail()
+//            }, onFailure: { (error) -> Void in
+//                XCTAssertNotNil(error)
+//                expectation.fulfill()
+//        })
+//
+//        waitForExpectationsWithTimeout(5.0, handler: nil)
+//    }
 }

--- a/KakicoTests/Classes/Models/APIClientTests.swift
+++ b/KakicoTests/Classes/Models/APIClientTests.swift
@@ -2,14 +2,6 @@ import XCTest
 
 class APIClientTests: XCTestCase {
     let apiClient = APIClient()
-    override func setUp() {
-        super.setUp()
-    }
-    
-    override func tearDown() {
-        super.tearDown()
-    }
-
 
     func testGetUserSuccess() {
         let expectation = expectationWithDescription("getUserSuccess")

--- a/KakicoTests/Classes/Models/APIClientTests.swift
+++ b/KakicoTests/Classes/Models/APIClientTests.swift
@@ -15,7 +15,7 @@ class APIClientTests: XCTestCase {
                 XCTAssertEqual(sample!.id, userId)
                 expectation.fulfill()
             }, onFailure: { (error) -> Void in
-                XCTFail("")
+                XCTFail()
         })
 
         waitForExpectationsWithTimeout(5.0, handler: nil)

--- a/KakicoTests/Classes/Models/APIClientTests.swift
+++ b/KakicoTests/Classes/Models/APIClientTests.swift
@@ -6,13 +6,10 @@ class APIClientTests: XCTestCase {
     func testGetUserSuccess() {
         let expectation = expectationWithDescription("getUserSuccess")
 
-        var sample: User? = nil
-
         let userId = 1
         apiClient.getUser(userId,
             onSuccess: { (user) -> Void in
-                sample = user
-                XCTAssertEqual(sample!.id, userId)
+                XCTAssertEqual(user.id, userId)
                 expectation.fulfill()
             }, onFailure: { (error) -> Void in
                 XCTFail()
@@ -24,13 +21,12 @@ class APIClientTests: XCTestCase {
     func testGetUserFailure() {
         let expectation = expectationWithDescription("getUserFailure")
 
-        var sample: User? = nil
         let userId = 999999
         apiClient.getUser(userId,
             onSuccess: { (user) -> Void in
                 XCTFail()
             }, onFailure: { (error) -> Void in
-                XCTAssertTrue(sample == nil)
+                XCTAssertNotNil(error)
                 expectation.fulfill()
         })
 

--- a/KakicoTests/Classes/Models/APIClientTests.swift
+++ b/KakicoTests/Classes/Models/APIClientTests.swift
@@ -20,14 +20,14 @@ class APIClientTests: XCTestCase {
         apiClient.getUser(userId,
             onSuccess: { (user) -> Void in
                 sample = user
+                XCTAssertEqual(sample!.id, userId)
                 expectation.fulfill()
             }, onFailure: { (error) -> Void in
+                XCTFail("")
                 expectation.fulfill()
         })
 
         waitForExpectationsWithTimeout(5.0, handler: nil)
-
-        XCTAssertEqual(sample!.id, userId)
     }
 
     func testGetUserFailure() {
@@ -37,14 +37,13 @@ class APIClientTests: XCTestCase {
         let userId = 999999
         apiClient.getUser(userId,
             onSuccess: { (user) -> Void in
-                sample = user
+                XCTFail()
                 expectation.fulfill()
             }, onFailure: { (error) -> Void in
+                XCTAssertTrue(sample == nil)
                 expectation.fulfill()
         })
 
         waitForExpectationsWithTimeout(5.0, handler: nil)
-
-        XCTAssertTrue(sample == nil)
     }
 }

--- a/KakicoTests/Classes/Models/UserTests.swift
+++ b/KakicoTests/Classes/Models/UserTests.swift
@@ -1,0 +1,16 @@
+import UIKit
+import XCTest
+
+class UserTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testExample() {
+        XCTAssert(true, "Pass")
+    }
+}

--- a/KakicoTests/Classes/Models/UserTests.swift
+++ b/KakicoTests/Classes/Models/UserTests.swift
@@ -10,7 +10,29 @@ class UserTests: XCTestCase {
         super.tearDown()
     }
 
-    func testExample() {
-        XCTAssert(true, "Pass")
+    func createUser() {
+        let contents = [
+            "created_at" : "2015-08-24T09:59:06.000Z",
+            "email" : "test@test.com",
+            "followers_count" : 10,
+            "following_count" : 20,
+            "following_flag" : 1,
+            "icon_url" : "https://secure.gravatar.com/avatar",
+            "id" : 1,
+            "microposts_count" : 51,
+            "name" : "hoge",
+            "unix_time_created_at" : 1440410346,
+            "unix_time_updated_at" : 1441939154,
+            "updated_at" : "2015-09-11T02:39:14.000Z",
+        ]
+
+        let icon = NSURL(string: contents["icon_url"] as! String)!
+        let user = User(
+            id: contents["id"] as! Int,
+            name: contents["name"] as! String,
+            icon: icon,
+            followingFlag: contents["following_flag"] as! Bool
+        )
+        XCTAssertEqual(user.id, contents["id"] as! Int)
     }
 }

--- a/KakicoTests/Classes/Models/UserTests.swift
+++ b/KakicoTests/Classes/Models/UserTests.swift
@@ -1,5 +1,6 @@
 import UIKit
 import XCTest
+import SwiftyJSON
 
 class UserTests: XCTestCase {
     override func setUp() {
@@ -11,7 +12,7 @@ class UserTests: XCTestCase {
     }
 
     func createUser() {
-        let contents = [
+        let contents: JSON = [
             "created_at" : "2015-08-24T09:59:06.000Z",
             "email" : "test@test.com",
             "followers_count" : 10,
@@ -26,13 +27,14 @@ class UserTests: XCTestCase {
             "updated_at" : "2015-09-11T02:39:14.000Z",
         ]
 
-        let icon = NSURL(string: contents["icon_url"] as! String)!
-        let user = User(
-            id: contents["id"] as! Int,
-            name: contents["name"] as! String,
-            icon: icon,
-            followingFlag: contents["following_flag"] as! Bool
-        )
-        XCTAssertEqual(user.id, contents["id"] as! Int)
+        let user = User(data: contents)
+        XCTAssertEqual(user.id, contents["id"].int!)
+        XCTAssertEqual(user.name, contents["name"].string!)
+        XCTAssertEqual(user.email, contents["email"].string!)
+        XCTAssertEqual(user.icon, NSURL(string: contents["icon_url"].string!)!)
+        XCTAssertEqual(user.micropostsCount, contents["microposts_count"].int!)
+        XCTAssertEqual(user.followersCount, contents["followers_count"].int!)
+        XCTAssertEqual(user.followingCount, contents["following_count"].int!)
+        XCTAssertEqual(user.followingFlag, contents["following_flag"].bool!)
     }
 }

--- a/KakicoTests/Classes/Models/UserTests.swift
+++ b/KakicoTests/Classes/Models/UserTests.swift
@@ -11,13 +11,13 @@ class UserTests: XCTestCase {
         super.tearDown()
     }
 
-    func createUser() {
+    func testCreateUser() {
         let contents: JSON = [
             "created_at" : "2015-08-24T09:59:06.000Z",
             "email" : "test@test.com",
             "followers_count" : 10,
             "following_count" : 20,
-            "following_flag" : 1,
+            "following_flag" : true,
             "icon_url" : "https://secure.gravatar.com/avatar",
             "id" : 1,
             "microposts_count" : 51,

--- a/KakicoTests/KakicoTests.swift
+++ b/KakicoTests/KakicoTests.swift
@@ -1,7 +1,0 @@
-import UIKit
-import XCTest
-
-class KakicoTests: XCTestCase {
-    func testMicropostInitialization() {
-    }
-}

--- a/KakicoTests/UserTests.swift
+++ b/KakicoTests/UserTests.swift
@@ -1,5 +1,0 @@
-import UIKit
-import XCTest
-
-class UserTests: XCTestCase {
-}

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,20 @@ DEVICE = iPhone 6
 test:
 	set -o pipefail && \
 	xcodebuild -workspace $(PROJECT) \
-		   -scheme $(TEST_TARGET) \
-		   -sdk iphonesimulator \
-		   -configuration Debug \
-		   -destination platform='iOS Simulator',OS=$(OS),name='$(DEVICE)' \
-		   clean test | \
-		   bundle exec xcpretty -c
+		-scheme $(TEST_TARGET) \
+		-sdk iphonesimulator \
+		-configuration Debug \
+		-destination platform='iOS Simulator',OS=$(OS),name='$(DEVICE)' \
+		clean test | \
+		bundle exec xcpretty -c
+
+debug-test:
+	xcodebuild -workspace $(PROJECT) \
+		-scheme $(TEST_TARGET) \
+		-sdk iphonesimulator \
+		-configuration Debug \
+		-destination platform='iOS Simulator',OS=$(OS),name='$(DEVICE)' \
+		clean test
 
 deploy:
 	bundle exec ipa build -w Kakico.xcworkspace -s Kakico && \


### PR DESCRIPTION
これまでは通信したときにJSONのようなdataが返ってきて、よしなに整形して扱う必要がありました。それではViewControllerが重すぎる！つらい！
ということで、きちんとAPIClientさんを用意して、適当なモデルのインスタンスを返してくれるように修正していきます。
今回はそれのgetUser版。

これからのgetUser。

```
let apiClient = APIClient()
apiClient.getUser(userId,
    onSuccess: { (user) -> Void in
        // userがUserのインスタンスになってる
    }, onFailure: { (error) -> Void in
})
```
