### PR TITLE
ポスト投稿画面にて、選択した画像を削除できる

### DIFF
--- a/Kakico/Classes/Controllers/NewPostlViewController.swift
+++ b/Kakico/Classes/Controllers/NewPostlViewController.swift
@@ -31,6 +31,12 @@ class NewPostViewController: UIViewController, UITextViewDelegate, UIImagePicker
         presentViewController(imagePickerController, animated: true, completion: nil)
     }
 
+    @IBAction func deletePicture(sender: AnyObject) {
+        if self.pictureImageView.image != nil {
+            selectAlert()
+        }
+    }
+
     @IBAction func save(sender: UIBarButtonItem) {
         post(contentField.text, picture: pictureImageView.image)
     }
@@ -38,6 +44,21 @@ class NewPostViewController: UIViewController, UITextViewDelegate, UIImagePicker
     @IBAction func cancel(sender: UIBarButtonItem) {
         contentField.resignFirstResponder()
         dismissViewControllerAnimated(true, completion: nil)
+    }
+
+    func selectAlert() {
+        let alertController = UIAlertController(title: "Are you sure you want to delete the image?", message: "", preferredStyle: .ActionSheet)
+        let logoutAction = UIAlertAction(title: "Delete", style: .Default) {
+            action in self.pictureImageView.image = nil
+        }
+        let cancelAction = UIAlertAction(title: "Cancel", style: .Cancel) {
+            action in println("Cancel")
+        }
+
+        alertController.addAction(logoutAction)
+        alertController.addAction(cancelAction)
+
+        presentViewController(alertController, animated: true, completion: nil)
     }
 
     // MARK: - UITextFieldDelegate

--- a/Kakico/Classes/Controllers/NewPostlViewController.swift
+++ b/Kakico/Classes/Controllers/NewPostlViewController.swift
@@ -33,7 +33,7 @@ class NewPostViewController: UIViewController, UITextViewDelegate, UIImagePicker
 
     @IBAction func deletePicture(sender: AnyObject) {
         if self.pictureImageView.image != nil {
-            selectAlert()
+            showDeletingAlert()
         }
     }
 
@@ -46,13 +46,13 @@ class NewPostViewController: UIViewController, UITextViewDelegate, UIImagePicker
         dismissViewControllerAnimated(true, completion: nil)
     }
 
-    func selectAlert() {
-        let alertController = UIAlertController(title: "Are you sure you want to delete the image?", message: "", preferredStyle: .ActionSheet)
+    func showDeletingAlert() {
+        let alertController = UIAlertController(title: "Are you sure you want to delete the picture?", message: "", preferredStyle: .ActionSheet)
         let logoutAction = UIAlertAction(title: "Delete", style: .Default) {
             action in self.pictureImageView.image = nil
         }
         let cancelAction = UIAlertAction(title: "Cancel", style: .Cancel) {
-            action in println("Cancel")
+            action in println("Delete picture canceled")
         }
 
         alertController.addAction(logoutAction)

--- a/Kakico/Classes/Storyboards/Main.storyboard
+++ b/Kakico/Classes/Storyboards/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="1o7-qB-Pic">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="1o7-qB-Pic">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
         <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
@@ -247,7 +247,7 @@
                                             <outlet property="delegate" destination="BYZ-38-t0r" id="H6q-0W-Q2P"/>
                                         </connections>
                                     </textView>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="iFx-V5-qcZ">
+                                    <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="iFx-V5-qcZ">
                                         <rect key="frame" x="0.0" y="0.0" width="240" height="128"/>
                                         <gestureRecognizers/>
                                         <constraints>
@@ -267,7 +267,7 @@
                                             </mask>
                                         </variation>
                                         <connections>
-                                            <outletCollection property="gestureRecognizers" destination="35F-js-VD3" appends="YES" id="jW9-rH-8wc"/>
+                                            <outletCollection property="gestureRecognizers" destination="KPh-b0-S07" appends="YES" id="cvQ-6b-XIE"/>
                                         </connections>
                                     </imageView>
                                 </subviews>
@@ -370,6 +370,11 @@
                         <action selector="unFocusTextField:" destination="BYZ-38-t0r" id="JLn-vk-AzE"/>
                     </connections>
                 </tapGestureRecognizer>
+                <pongPressGestureRecognizer allowableMovement="10" minimumPressDuration="0.5" id="KPh-b0-S07">
+                    <connections>
+                        <action selector="deletePicture:" destination="BYZ-38-t0r" id="bSp-bF-bKd"/>
+                    </connections>
+                </pongPressGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="1522.5" y="-484"/>
         </scene>


### PR DESCRIPTION
@orzup @alotofwe 

今までだとポスト投稿画面から一度でも画像を選択してしまうと文章のみの投稿ができない状態だったのを、選択した画像のサムネイルをロングタップすることで画像の削除をすることができるようにしたいと思います。
### merge条件
- [x] @orzup or @alotofwe  が動作確認をすること
  - [x] 選択した画像のサムネをロングタップすると削除アラートが表示されること
  - [x] アラートのDeleteを選択すると画像が削除されサムネが非表示になること
- [x] TravisCIがグリーンであること
