### PR TITLE
プロフィール画面から、そのユーザのfollowing/followersリストへ遷移できる

### DIFF
--- a/Kakico/Classes/Controllers/ProfileHeaderViewController.swift
+++ b/Kakico/Classes/Controllers/ProfileHeaderViewController.swift
@@ -96,6 +96,7 @@ class ProfileHeaderViewController: UIViewController {
             default:
                 println("undefined segue.identifier in ConfigViewController")
             }
+            userView._selectedId = _selectUserId
         }
     }
 }

--- a/Kakico/Classes/Controllers/ProfileHeaderViewController.swift
+++ b/Kakico/Classes/Controllers/ProfileHeaderViewController.swift
@@ -84,4 +84,18 @@ class ProfileHeaderViewController: UIViewController {
         button.setTitle("Follow", forState: .Normal)
         button.setTitleColor(UIColor.DefaultColor(), forState: .Normal)
     }
+
+    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject!) {
+        if let userView = segue.destinationViewController as? UserViewController {
+            let type = segue.identifier!
+            switch type {
+            case "Followers":
+                userView._listType = "Followers"
+            case "Following":
+                userView._listType = "Following"
+            default:
+                println("undefined segue.identifier in ConfigViewController")
+            }
+        }
+    }
 }

--- a/Kakico/Classes/Controllers/UserViewController.swift
+++ b/Kakico/Classes/Controllers/UserViewController.swift
@@ -7,7 +7,8 @@ import UIScrollView_InfiniteScroll
 class UserViewController: UITableViewController {
     // MARK: - Properties
     var users = UserDataManager()
-    var userId = 0
+    var myId = 0
+    var _selectedId = 0
     var _listType = ""
     
     // MARK: - View Events
@@ -44,9 +45,13 @@ class UserViewController: UITableViewController {
 
         let keychain = Keychain(service: "nehan.Kakico")
         if let id = keychain["userId"] {
-            userId = id.toInt()!
+            myId = id.toInt()!
         }
-        
+
+        if _selectedId == 0 {
+            _selectedId = myId
+        }
+
         let params = [
             "page": String(page)
         ]
@@ -57,11 +62,11 @@ class UserViewController: UITableViewController {
                 self.setUserList(data)
             }
         case "Followers":
-            Alamofire.request(Router.GetFollowers(userId: userId, params: params)).responseJSON { (request, response, data, error) -> Void in
+            Alamofire.request(Router.GetFollowers(userId: _selectedId, params: params)).responseJSON { (request, response, data, error) -> Void in
                 self.setUserList(data)
             }
         case "Following":
-            Alamofire.request(Router.GetFollowing(userId: userId, params: params)).responseJSON { (request, response, data, error) -> Void in
+            Alamofire.request(Router.GetFollowing(userId: _selectedId, params: params)).responseJSON { (request, response, data, error) -> Void in
                 self.setUserList(data)
             }
         default:
@@ -101,7 +106,7 @@ class UserViewController: UITableViewController {
         button.hidden = false
         button.tag = user.id
 
-        if user.id == userId {
+        if user.id == myId {
             button.hidden = true
         }else if user.followingFlag {
             followButtonStyle(button)

--- a/Kakico/Classes/Storyboards/Main.storyboard
+++ b/Kakico/Classes/Storyboards/Main.storyboard
@@ -1278,6 +1278,9 @@
                                                         <include reference="eQi-wV-fzp"/>
                                                     </mask>
                                                 </variation>
+                                                <connections>
+                                                    <segue destination="NIT-Rz-oJj" kind="show" identifier="Following" id="5g7-tu-h7j"/>
+                                                </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Following" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gUU-zN-14g">
                                                 <rect key="frame" x="0.0" y="-21" width="42" height="21"/>
@@ -1348,6 +1351,9 @@
                                                 <state key="normal" title="55">
                                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                                 </state>
+                                                <connections>
+                                                    <segue destination="NIT-Rz-oJj" kind="show" identifier="Followers" id="nrx-Rj-cYL"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XxY-A2-tRP" userLabel="Following Count">
                                                 <rect key="frame" x="-23" y="-15" width="46" height="30"/>
@@ -2305,7 +2311,7 @@
         <image name="micropost1" width="400" height="264"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="R1A-dp-hUo"/>
+        <segue reference="nrx-Rj-cYL"/>
         <segue reference="eph-rC-yrT"/>
     </inferredMetricsTieBreakers>
 </document>


### PR DESCRIPTION
@orzup @alotofwe 

プロフィール画面に表示されているfollowing/followers数をタップすることで、そのユーザのfollowing/followersリストへ画面遷移するようにします。
### merge条件
- [x] @orzup or @alotofwe  が動作確認をすること
  - [x] プロフィールヘッダーから各リストへ遷移できること
    - following
    - followers
  - [x] profile > following(or followers) と遷移してきたときにも、リストにいる自分はフォローできないようになっていること
- [x] TravisCIがグリーンであること
