### PR TITLE
ユーザリストにて、余白部分のセルの境界線を消す

### DIFF
--- a/Kakico/Classes/Controllers/UserViewController.swift
+++ b/Kakico/Classes/Controllers/UserViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import SVProgressHUD
 import Alamofire
 import SwiftyJSON
 import KeychainAccess
@@ -14,6 +15,8 @@ class UserViewController: UITableViewController {
     // MARK: - View Events
     override func viewDidLoad() {
         super.viewDidLoad()
+        resetSeparatorStyle()
+        SVProgressHUD.showWithMaskType(.Black)
         request(_listType, page: 1)
 
         // Add infinite scroll handler
@@ -28,6 +31,13 @@ class UserViewController: UITableViewController {
             
             tableView.finishInfiniteScroll()
         }
+    }
+
+    override func viewDidAppear(animated: Bool) {
+        super.viewDidAppear(animated)
+        self.tableView.reloadData()
+        resetSeparatorStyle()
+        SVProgressHUD.dismiss()
     }
 
     @IBAction func toggleFollow(sender: followButton) {
@@ -133,6 +143,14 @@ class UserViewController: UITableViewController {
         }
     }
 
+    func resetSeparatorStyle() -> Void {
+        if self.users.size == 0 {
+            self.tableView.separatorStyle = UITableViewCellSeparatorStyle.None
+        } else {
+            self.tableView.separatorStyle = UITableViewCellSeparatorStyle.SingleLine
+        }
+    }
+
     // MARK: - Table view data source
     override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
         return 1
@@ -152,6 +170,14 @@ class UserViewController: UITableViewController {
         initFollowButton(cell.followButton as! followButton, user: user)
 
         return cell
+    }
+
+    override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return 1
+    }
+
+    override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        return UIView()
     }
 
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject!) {

--- a/Kakico/Classes/Controllers/UserViewController.swift
+++ b/Kakico/Classes/Controllers/UserViewController.swift
@@ -33,13 +33,6 @@ class UserViewController: UITableViewController {
         }
     }
 
-    override func viewDidAppear(animated: Bool) {
-        super.viewDidAppear(animated)
-        self.tableView.reloadData()
-        resetSeparatorStyle()
-        SVProgressHUD.dismiss()
-    }
-
     @IBAction func toggleFollow(sender: followButton) {
         if sender.isFollowing() {
             follow(sender.tag)
@@ -98,6 +91,8 @@ class UserViewController: UITableViewController {
 
             dispatch_async(dispatch_get_main_queue(), {
                 self.tableView!.reloadData()
+                self.resetSeparatorStyle()
+                SVProgressHUD.dismiss()
             })
 
         }

--- a/Kakico/Classes/Controllers/UserViewController.swift
+++ b/Kakico/Classes/Controllers/UserViewController.swift
@@ -91,10 +91,9 @@ class UserViewController: UITableViewController {
 
             dispatch_async(dispatch_get_main_queue(), {
                 self.tableView!.reloadData()
-                self.resetSeparatorStyle()
-                SVProgressHUD.dismiss()
             })
-
+            self.resetSeparatorStyle()
+            SVProgressHUD.dismiss()
         }
     }
 


### PR DESCRIPTION
@orzup @alotofwe 

表示するセルがないのに境界線だけ表示されているのは不自然なので、セルの数に合わせて不要な境界線を消すようにします。
### merge条件
- [x] 動作確認をすること
  - [x] 各ユーザリスト(all, followering, followers)にて、余白部分に境界線が表示されていないこと
    - [x] 表示するユーザがいない場合は画面が真っ白であること
- [x] Passed CI
