### PR TITLE
プロフィールにて、following/followersリストへ遷移できるタップ領域を広げる

### DIFF
--- a/Kakico/Classes/Storyboards/Main.storyboard
+++ b/Kakico/Classes/Storyboards/Main.storyboard
@@ -1076,7 +1076,7 @@
             <objects>
                 <tableViewController id="NIT-Rz-oJj" customClass="UserViewController" customModule="Kakico" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="66" sectionHeaderHeight="22" sectionFooterHeight="22" id="7uq-mq-iFI">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="400" height="230"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
@@ -1282,16 +1282,14 @@
                                                         <exclude reference="eQi-wV-fzp"/>
                                                     </mask>
                                                 </variation>
-                                                <variation key="widthClass=compact">
+                                                <variation key="widthClass=compact" misplaced="YES">
+                                                    <rect key="frame" x="101" y="24" width="80" height="30"/>
                                                     <mask key="constraints">
                                                         <include reference="Mgn-8I-oMV"/>
                                                         <include reference="To4-oW-SyR"/>
                                                         <include reference="eQi-wV-fzp"/>
                                                     </mask>
                                                 </variation>
-                                                <connections>
-                                                    <segue destination="NIT-Rz-oJj" kind="show" identifier="Following" id="5g7-tu-h7j"/>
-                                                </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Following" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gUU-zN-14g">
                                                 <rect key="frame" x="0.0" y="-21" width="42" height="21"/>
@@ -1310,7 +1308,8 @@
                                                         <exclude reference="tqJ-XV-ft9"/>
                                                     </mask>
                                                 </variation>
-                                                <variation key="widthClass=compact">
+                                                <variation key="widthClass=compact" misplaced="YES">
+                                                    <rect key="frame" x="101" y="0.0" width="80" height="21"/>
                                                     <mask key="constraints">
                                                         <include reference="99f-kj-SHx"/>
                                                         <include reference="L2h-oU-5dc"/>
@@ -1362,9 +1361,6 @@
                                                 <state key="normal" title="55">
                                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                                 </state>
-                                                <connections>
-                                                    <segue destination="NIT-Rz-oJj" kind="show" identifier="Followers" id="nrx-Rj-cYL"/>
-                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XxY-A2-tRP" userLabel="Following Count">
                                                 <rect key="frame" x="-23" y="-15" width="46" height="30"/>
@@ -1400,6 +1396,56 @@
                                                     <action selector="toggleFollow:" destination="4rZ-fU-Zsn" eventType="touchUpInside" id="gVr-pQ-440"/>
                                                 </connections>
                                             </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7jd-7V-Hbi" userLabel="Following Button">
+                                                <rect key="frame" x="-23" y="-15" width="46" height="30"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="54" id="HXE-oU-i32"/>
+                                                    <constraint firstAttribute="width" constant="80" id="VcN-eC-AnM"/>
+                                                </constraints>
+                                                <state key="normal">
+                                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                                </state>
+                                                <variation key="default">
+                                                    <mask key="constraints">
+                                                        <exclude reference="HXE-oU-i32"/>
+                                                        <exclude reference="VcN-eC-AnM"/>
+                                                    </mask>
+                                                </variation>
+                                                <variation key="widthClass=compact">
+                                                    <mask key="constraints">
+                                                        <include reference="HXE-oU-i32"/>
+                                                        <include reference="VcN-eC-AnM"/>
+                                                    </mask>
+                                                </variation>
+                                                <connections>
+                                                    <segue destination="NIT-Rz-oJj" kind="show" identifier="Following" id="6jz-1V-Yxg"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="r95-t5-rWC" userLabel="Followers Button">
+                                                <rect key="frame" x="-23" y="-15" width="46" height="30"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="80" id="T7c-OV-btK"/>
+                                                    <constraint firstAttribute="height" constant="54" id="qig-V2-jGf"/>
+                                                </constraints>
+                                                <state key="normal">
+                                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                                </state>
+                                                <variation key="default">
+                                                    <mask key="constraints">
+                                                        <exclude reference="T7c-OV-btK"/>
+                                                        <exclude reference="qig-V2-jGf"/>
+                                                    </mask>
+                                                </variation>
+                                                <variation key="widthClass=compact">
+                                                    <mask key="constraints">
+                                                        <include reference="T7c-OV-btK"/>
+                                                        <include reference="qig-V2-jGf"/>
+                                                    </mask>
+                                                </variation>
+                                                <connections>
+                                                    <segue destination="NIT-Rz-oJj" kind="show" identifier="Followers" id="0n2-DH-ndl"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <constraints>
@@ -1407,23 +1453,31 @@
                                                 <variation key="widthClass=compact" constant="15"/>
                                             </constraint>
                                             <constraint firstItem="XxY-A2-tRP" firstAttribute="top" secondItem="kTc-r3-ujn" secondAttribute="bottom" constant="3" id="2pM-yp-PDh"/>
+                                            <constraint firstItem="pZi-CT-QJI" firstAttribute="top" secondItem="r95-t5-rWC" secondAttribute="bottom" constant="9" id="3KM-G0-iFH"/>
                                             <constraint firstItem="pZi-CT-QJI" firstAttribute="top" secondItem="gNc-ur-DTs" secondAttribute="bottom" constant="9" id="5vI-bL-ty7"/>
+                                            <constraint firstItem="pZi-CT-QJI" firstAttribute="top" secondItem="7jd-7V-Hbi" secondAttribute="bottom" constant="9" id="67H-Gr-4W9"/>
                                             <constraint firstItem="gUU-zN-14g" firstAttribute="top" secondItem="N2L-zN-hae" secondAttribute="top" id="6GN-FB-oAO"/>
                                             <constraint firstItem="gUU-zN-14g" firstAttribute="width" secondItem="FLb-Ac-Zau" secondAttribute="width" id="6q3-ay-r22"/>
                                             <constraint firstItem="gUU-zN-14g" firstAttribute="width" secondItem="kTc-r3-ujn" secondAttribute="width" id="8fu-ap-7Yi"/>
                                             <constraint firstItem="kTc-r3-ujn" firstAttribute="centerX" secondItem="XxY-A2-tRP" secondAttribute="centerX" id="9sS-SE-75y"/>
                                             <constraint firstItem="mob-j2-Ijd" firstAttribute="top" secondItem="kTc-r3-ujn" secondAttribute="top" id="Ale-nb-4CP"/>
                                             <constraint firstItem="gUU-zN-14g" firstAttribute="width" secondItem="mob-j2-Ijd" secondAttribute="width" id="BWL-uG-fzw"/>
+                                            <constraint firstItem="r95-t5-rWC" firstAttribute="leading" secondItem="7jd-7V-Hbi" secondAttribute="trailing" constant="23" id="Flm-Il-jx7"/>
+                                            <constraint firstItem="r95-t5-rWC" firstAttribute="leading" secondItem="7jd-7V-Hbi" secondAttribute="trailing" constant="23" id="GpM-7t-eky"/>
                                             <constraint firstAttribute="trailing" secondItem="pZi-CT-QJI" secondAttribute="trailing" id="IJG-Tz-q23">
                                                 <variation key="widthClass=compact" constant="15"/>
                                             </constraint>
                                             <constraint firstAttribute="centerX" secondItem="pZi-CT-QJI" secondAttribute="centerX" id="M1h-IO-sr0"/>
+                                            <constraint firstItem="7jd-7V-Hbi" firstAttribute="top" secondItem="N2L-zN-hae" secondAttribute="top" id="NsB-u7-NhF"/>
                                             <constraint firstAttribute="trailing" secondItem="mob-j2-Ijd" secondAttribute="trailing" id="Q4x-wK-7Jd"/>
                                             <constraint firstItem="gNc-ur-DTs" firstAttribute="top" secondItem="mob-j2-Ijd" secondAttribute="bottom" constant="3" id="Wpu-tO-RuA"/>
+                                            <constraint firstItem="7jd-7V-Hbi" firstAttribute="leading" secondItem="XxY-A2-tRP" secondAttribute="trailing" constant="21" id="Y4B-wU-mLt"/>
                                             <constraint firstItem="mob-j2-Ijd" firstAttribute="top" secondItem="gUU-zN-14g" secondAttribute="top" id="Yey-UY-Nbn"/>
                                             <constraint firstAttribute="centerX" secondItem="FLb-Ac-Zau" secondAttribute="centerX" id="bCH-qg-eRX"/>
+                                            <constraint firstItem="r95-t5-rWC" firstAttribute="top" secondItem="N2L-zN-hae" secondAttribute="top" id="bD0-nW-sig"/>
                                             <constraint firstItem="kTc-r3-ujn" firstAttribute="leading" secondItem="N2L-zN-hae" secondAttribute="leading" id="ekp-VT-DxS"/>
                                             <constraint firstItem="gUU-zN-14g" firstAttribute="width" secondItem="gNc-ur-DTs" secondAttribute="width" id="hE1-oL-Ob8"/>
+                                            <constraint firstAttribute="trailing" secondItem="r95-t5-rWC" secondAttribute="trailing" id="iFy-N0-hel"/>
                                             <constraint firstItem="pZi-CT-QJI" firstAttribute="top" secondItem="FLb-Ac-Zau" secondAttribute="bottom" constant="9" id="jAc-8A-IRE"/>
                                             <constraint firstAttribute="centerX" secondItem="gUU-zN-14g" secondAttribute="centerX" id="kem-5Y-RLW"/>
                                             <constraint firstAttribute="bottom" secondItem="pZi-CT-QJI" secondAttribute="bottom" constant="8" id="oek-Uk-FMn"/>
@@ -1441,32 +1495,42 @@
                                                 <exclude reference="gNc-ur-DTs"/>
                                                 <exclude reference="XxY-A2-tRP"/>
                                                 <exclude reference="pZi-CT-QJI"/>
+                                                <exclude reference="7jd-7V-Hbi"/>
+                                                <exclude reference="r95-t5-rWC"/>
                                             </mask>
                                             <mask key="constraints">
+                                                <exclude reference="9sS-SE-75y"/>
+                                                <exclude reference="ekp-VT-DxS"/>
+                                                <exclude reference="2pM-yp-PDh"/>
+                                                <exclude reference="1ff-nV-gPR"/>
+                                                <exclude reference="3KM-G0-iFH"/>
+                                                <exclude reference="5vI-bL-ty7"/>
+                                                <exclude reference="67H-Gr-4W9"/>
+                                                <exclude reference="IJG-Tz-q23"/>
+                                                <exclude reference="M1h-IO-sr0"/>
+                                                <exclude reference="jAc-8A-IRE"/>
+                                                <exclude reference="oek-Uk-FMn"/>
+                                                <exclude reference="oqz-rO-V2V"/>
+                                                <exclude reference="NsB-u7-NhF"/>
+                                                <exclude reference="Y4B-wU-mLt"/>
                                                 <exclude reference="6GN-FB-oAO"/>
                                                 <exclude reference="6q3-ay-r22"/>
                                                 <exclude reference="8fu-ap-7Yi"/>
                                                 <exclude reference="BWL-uG-fzw"/>
                                                 <exclude reference="hE1-oL-Ob8"/>
                                                 <exclude reference="kem-5Y-RLW"/>
-                                                <exclude reference="9sS-SE-75y"/>
-                                                <exclude reference="ekp-VT-DxS"/>
+                                                <exclude reference="bCH-qg-eRX"/>
+                                                <exclude reference="q2n-HT-Aoz"/>
                                                 <exclude reference="Ale-nb-4CP"/>
                                                 <exclude reference="Q4x-wK-7Jd"/>
                                                 <exclude reference="Yey-UY-Nbn"/>
                                                 <exclude reference="t63-lX-A2b"/>
-                                                <exclude reference="bCH-qg-eRX"/>
-                                                <exclude reference="q2n-HT-Aoz"/>
-                                                <exclude reference="2pM-yp-PDh"/>
+                                                <exclude reference="Flm-Il-jx7"/>
+                                                <exclude reference="GpM-7t-eky"/>
+                                                <exclude reference="bD0-nW-sig"/>
+                                                <exclude reference="iFy-N0-hel"/>
                                                 <exclude reference="Wpu-tO-RuA"/>
                                                 <exclude reference="x8g-ZE-7FO"/>
-                                                <exclude reference="1ff-nV-gPR"/>
-                                                <exclude reference="5vI-bL-ty7"/>
-                                                <exclude reference="IJG-Tz-q23"/>
-                                                <exclude reference="M1h-IO-sr0"/>
-                                                <exclude reference="jAc-8A-IRE"/>
-                                                <exclude reference="oek-Uk-FMn"/>
-                                                <exclude reference="oqz-rO-V2V"/>
                                             </mask>
                                         </variation>
                                         <variation key="widthClass=compact">
@@ -1478,32 +1542,42 @@
                                                 <include reference="gNc-ur-DTs"/>
                                                 <include reference="XxY-A2-tRP"/>
                                                 <include reference="pZi-CT-QJI"/>
+                                                <include reference="7jd-7V-Hbi"/>
+                                                <include reference="r95-t5-rWC"/>
                                             </mask>
                                             <mask key="constraints">
+                                                <include reference="9sS-SE-75y"/>
+                                                <include reference="ekp-VT-DxS"/>
+                                                <include reference="2pM-yp-PDh"/>
+                                                <include reference="1ff-nV-gPR"/>
+                                                <include reference="3KM-G0-iFH"/>
+                                                <include reference="5vI-bL-ty7"/>
+                                                <include reference="67H-Gr-4W9"/>
+                                                <include reference="IJG-Tz-q23"/>
+                                                <include reference="M1h-IO-sr0"/>
+                                                <include reference="jAc-8A-IRE"/>
+                                                <include reference="oek-Uk-FMn"/>
+                                                <include reference="oqz-rO-V2V"/>
+                                                <include reference="NsB-u7-NhF"/>
+                                                <include reference="Y4B-wU-mLt"/>
                                                 <include reference="6GN-FB-oAO"/>
                                                 <include reference="6q3-ay-r22"/>
                                                 <include reference="8fu-ap-7Yi"/>
                                                 <include reference="BWL-uG-fzw"/>
                                                 <include reference="hE1-oL-Ob8"/>
                                                 <include reference="kem-5Y-RLW"/>
-                                                <include reference="9sS-SE-75y"/>
-                                                <include reference="ekp-VT-DxS"/>
+                                                <include reference="bCH-qg-eRX"/>
+                                                <include reference="q2n-HT-Aoz"/>
                                                 <include reference="Ale-nb-4CP"/>
                                                 <include reference="Q4x-wK-7Jd"/>
                                                 <include reference="Yey-UY-Nbn"/>
                                                 <include reference="t63-lX-A2b"/>
-                                                <include reference="bCH-qg-eRX"/>
-                                                <include reference="q2n-HT-Aoz"/>
-                                                <include reference="2pM-yp-PDh"/>
+                                                <include reference="Flm-Il-jx7"/>
+                                                <include reference="GpM-7t-eky"/>
+                                                <include reference="bD0-nW-sig"/>
+                                                <include reference="iFy-N0-hel"/>
                                                 <include reference="Wpu-tO-RuA"/>
                                                 <include reference="x8g-ZE-7FO"/>
-                                                <include reference="1ff-nV-gPR"/>
-                                                <include reference="5vI-bL-ty7"/>
-                                                <include reference="IJG-Tz-q23"/>
-                                                <include reference="M1h-IO-sr0"/>
-                                                <include reference="jAc-8A-IRE"/>
-                                                <include reference="oek-Uk-FMn"/>
-                                                <include reference="oqz-rO-V2V"/>
                                             </mask>
                                         </variation>
                                     </view>
@@ -2138,11 +2212,11 @@
             <objects>
                 <tableViewController id="Y87-VY-49y" customClass="ProfileViewController" customModule="Kakico" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="Rig-xa-LSt">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="400" height="230"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <containerView key="tableHeaderView" opaque="NO" contentMode="scaleToFill" id="waq-l5-QbF">
-                            <rect key="frame" x="0.0" y="64" width="600" height="230"/>
+                            <rect key="frame" x="0.0" y="0.0" width="400" height="230"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <connections>
                                 <segue destination="4rZ-fU-Zsn" kind="embed" identifier="ProfileHeaderView" id="BQD-C8-vJZ"/>
@@ -2326,7 +2400,7 @@
         <image name="micropost1" width="400" height="264"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="nrx-Rj-cYL"/>
+        <segue reference="0n2-DH-ndl"/>
         <segue reference="eph-rC-yrT"/>
     </inferredMetricsTieBreakers>
     <color key="tintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>


### PR DESCRIPTION
@orzup @alotofwe 

今までだとfollowing/followersリストへ遷移するためにはカウント部分をタップしなければならなかったのですがそれだと範囲が狭すぎてタップしづらいので、タップできる領域を広げます。
### merge条件
- [x] @orzup or @alotofwe  が動作確認をすること
  - [x] プロフィールにて、following/followersリストへ遷移できるタップ領域がラベル部分まで広がっていること
  - [x] タップして各リストへ遷移すること
