### PR TITLE
feedに戻ってきたときに毎回feedを自動更新する

### DIFF
--- a/Kakico/Classes/Controllers/FeedViewController.swift
+++ b/Kakico/Classes/Controllers/FeedViewController.swift
@@ -31,9 +31,8 @@ class FeedViewController: MicropostViewController {
     }
 
     func resetFeed() {
-        let feedSize = self.microposts.size
         let params = [
-            "size": String(feedSize)
+            "size": self.microposts.size
         ]
 
         Alamofire.request(Router.GetFeed(params: params)).responseJSON { (request, response, data, error) -> Void in
@@ -53,13 +52,13 @@ class FeedViewController: MicropostViewController {
         var params = Dictionary<String, AnyObject>()
 
         if let upper = upperId {
-            params["upper"] = String(upper)
+            params["upper"] = upper
         }
         if let lower = lowerId {
-            params["lower"] = String(lower)
+            params["lower"] = lower
         }
         if let s = size {
-            params["size"] = String(s)
+            params["size"] = s
         }
 
         Alamofire.request(Router.GetFeed(params: params)).responseJSON { (request, response, data, error) -> Void in

--- a/Kakico/Classes/Controllers/FeedViewController.swift
+++ b/Kakico/Classes/Controllers/FeedViewController.swift
@@ -13,7 +13,7 @@ class FeedViewController: MicropostViewController {
         // Add infinite scroll handler
         tableView.addInfiniteScrollWithHandler { (scrollView) -> Void in
             let tableView = scrollView as! UITableView
-            if (self.microposts.lowerId() != nil) {
+            if self.microposts.lowerId() != nil {
                 self.request(upperId: self.microposts.lowerId())
             }
             tableView.finishInfiniteScroll()
@@ -70,7 +70,7 @@ class FeedViewController: MicropostViewController {
     func addInfiniteScroll() {
         tableView.addInfiniteScrollWithHandler { (scrollView) -> Void in
             let tableView = scrollView as! UITableView
-            if (self.microposts.lowerId() != nil) {
+            if self.microposts.lowerId() != nil {
                 self.request(upperId: self.microposts.lowerId())
             }
             tableView.finishInfiniteScroll()

--- a/Kakico/Classes/Controllers/FeedViewController.swift
+++ b/Kakico/Classes/Controllers/FeedViewController.swift
@@ -18,11 +18,26 @@ class FeedViewController: MicropostViewController {
             }
             tableView.finishInfiniteScroll()
         }
-        super.viewDidLoad()
 
         self.refreshControl = UIRefreshControl()
         self.refreshControl!.addTarget(self, action: "refreshFeed", forControlEvents: UIControlEvents.ValueChanged)
         self.tableView.addSubview(refreshControl!)
+    }
+
+    override func viewDidAppear(animated: Bool) {
+        resetFeed()
+        super.viewDidAppear(animated)
+        self.tableView.reloadData()
+        resetSeparatorStyle()
+        SVProgressHUD.dismiss()
+    }
+
+    func resetFeed() {
+        Alamofire.request(Router.GetFeed(params: ["page": "1"])).responseJSON { (request, response, data, error) -> Void in
+            self.resetData()
+            self.setData(data)
+            self.addInfiniteScroll()
+        }
     }
     
     func refreshFeed() -> Void {

--- a/Kakico/Classes/Controllers/FeedViewController.swift
+++ b/Kakico/Classes/Controllers/FeedViewController.swift
@@ -25,7 +25,6 @@ class FeedViewController: MicropostViewController {
     }
 
     override func viewDidAppear(animated: Bool) {
-        SVProgressHUD.showWithMaskType(.Black)
         super.viewDidAppear(animated)
         resetFeed()
     }

--- a/Kakico/Classes/Controllers/FeedViewController.swift
+++ b/Kakico/Classes/Controllers/FeedViewController.swift
@@ -25,11 +25,9 @@ class FeedViewController: MicropostViewController {
     }
 
     override func viewDidAppear(animated: Bool) {
-        resetFeed()
+        SVProgressHUD.showWithMaskType(.Black)
         super.viewDidAppear(animated)
-        self.tableView.reloadData()
-        resetSeparatorStyle()
-        SVProgressHUD.dismiss()
+        resetFeed()
     }
 
     func resetFeed() {

--- a/Kakico/Classes/Controllers/FeedViewController.swift
+++ b/Kakico/Classes/Controllers/FeedViewController.swift
@@ -13,7 +13,7 @@ class FeedViewController: MicropostViewController {
         // Add infinite scroll handler
         tableView.addInfiniteScrollWithHandler { (scrollView) -> Void in
             let tableView = scrollView as! UITableView
-            if (self.microposts.lowerId() != 1 && self.microposts.lowerId() != nil) {
+            if (self.microposts.lowerId() != nil) {
                 self.request(upperId: self.microposts.lowerId())
             }
             tableView.finishInfiniteScroll()
@@ -33,7 +33,12 @@ class FeedViewController: MicropostViewController {
     }
 
     func resetFeed() {
-        Alamofire.request(Router.GetFeed(params: ["page": "1"])).responseJSON { (request, response, data, error) -> Void in
+        let feedSize = self.microposts.size
+        let params = [
+            "size": String(feedSize)
+        ]
+
+        Alamofire.request(Router.GetFeed(params: params)).responseJSON { (request, response, data, error) -> Void in
             self.resetData()
             self.setData(data)
             self.addInfiniteScroll()
@@ -68,7 +73,7 @@ class FeedViewController: MicropostViewController {
     func addInfiniteScroll() {
         tableView.addInfiniteScrollWithHandler { (scrollView) -> Void in
             let tableView = scrollView as! UITableView
-            if (self.microposts.lowerId() != 1 && self.microposts.lowerId() != nil) {
+            if (self.microposts.lowerId() != nil) {
                 self.request(upperId: self.microposts.lowerId())
             }
             tableView.finishInfiniteScroll()

--- a/Kakico/Classes/Controllers/FeedViewController.swift
+++ b/Kakico/Classes/Controllers/FeedViewController.swift
@@ -11,13 +11,7 @@ class FeedViewController: MicropostViewController {
         request(size: 30)
 
         // Add infinite scroll handler
-        tableView.addInfiniteScrollWithHandler { (scrollView) -> Void in
-            let tableView = scrollView as! UITableView
-            if self.microposts.lowerId() != nil {
-                self.request(upperId: self.microposts.lowerId())
-            }
-            tableView.finishInfiniteScroll()
-        }
+        addInfiniteScroll()
 
         self.refreshControl = UIRefreshControl()
         self.refreshControl!.addTarget(self, action: "refreshFeed", forControlEvents: UIControlEvents.ValueChanged)
@@ -37,7 +31,6 @@ class FeedViewController: MicropostViewController {
         Alamofire.request(Router.GetFeed(params: params)).responseJSON { (request, response, data, error) -> Void in
             self.resetData()
             self.setData(data)
-            self.addInfiniteScroll()
         }
     }
     
@@ -62,7 +55,6 @@ class FeedViewController: MicropostViewController {
 
         Alamofire.request(Router.GetFeed(params: params)).responseJSON { (request, response, data, error) -> Void in
             self.setData(data)
-            self.addInfiniteScroll()
         }
     }
 

--- a/Kakico/Classes/Controllers/MicropostViewController.swift
+++ b/Kakico/Classes/Controllers/MicropostViewController.swift
@@ -65,6 +65,10 @@ class MicropostViewController: UITableViewController, UITableViewDataSource, UIT
     }
 
     // MARK: -
+    func resetData() {
+        self.microposts = MicropostDataManager()
+    }
+
     func setData(data: AnyObject?) {
         println(data)
         if data != nil {

--- a/Kakico/Classes/Controllers/MicropostViewController.swift
+++ b/Kakico/Classes/Controllers/MicropostViewController.swift
@@ -63,7 +63,7 @@ class MicropostViewController: UITableViewController, UITableViewDataSource, UIT
 
     // MARK: -
     func resetData() {
-        self.microposts = MicropostDataManager()
+        self.microposts.drop()
     }
 
     func setData(data: AnyObject?) {

--- a/Kakico/Classes/Models/Micropost.swift
+++ b/Kakico/Classes/Models/Micropost.swift
@@ -60,6 +60,10 @@ class MicropostDataManager: NSObject {
         self.microposts = microposts + self.microposts
     }
 
+    func drop() {
+        self.microposts.removeAll()
+    }
+
     func lastUpdate() -> Int {
         if let micropost = microposts.first {
             return micropost.unixTimeCreatedAt


### PR DESCRIPTION
@orzup @alotofwe 

現状、 **feedに表示されているポスト** を更新する手段がありません。
これによって例えば
- 自分の名前をProfile editから更新してfeedに戻ったとき、すでに表示されているポストの名前は変わらない
- 誰かをフォローしたり、アンフォローしてからfeedに戻ったとき、その状態が反映されない

なので、feedに戻ったときには自動的に更新されるようにします。
### merge条件
- [x] @orzup or @alotofwe  が動作確認をすること
  - [x] 自分の名前を変更してからfeedに戻ると、変更した自分の名前が反映されていること
  - [x] ユーザをフォローしてからfeedに戻ると、そのユーザのポストが自分のfeedに表示されていること
