### PR TITLE
取得範囲を変更した新FeedAPIに対応する

### DIFF
--- a/Kakico/Classes/Controllers/FeedViewController.swift
+++ b/Kakico/Classes/Controllers/FeedViewController.swift
@@ -13,7 +13,7 @@ class FeedViewController: MicropostViewController {
         // Add infinite scroll handler
         tableView.addInfiniteScrollWithHandler { (scrollView) -> Void in
             let tableView = scrollView as! UITableView
-            if (self.microposts.lowerId() != nil) {
+            if (self.microposts.lowerId() != 1 && self.microposts.lowerId() != nil) {
                 self.request(upperId: self.microposts.lowerId())
             }
             tableView.finishInfiniteScroll()
@@ -52,7 +52,7 @@ class FeedViewController: MicropostViewController {
     func addInfiniteScroll() {
         tableView.addInfiniteScrollWithHandler { (scrollView) -> Void in
             let tableView = scrollView as! UITableView
-            if (self.microposts.nextPage != nil) {
+            if (self.microposts.lowerId() != 1 && self.microposts.lowerId() != nil) {
                 self.request(upperId: self.microposts.lowerId())
             }
             tableView.finishInfiniteScroll()

--- a/Kakico/Classes/Controllers/FeedViewController.swift
+++ b/Kakico/Classes/Controllers/FeedViewController.swift
@@ -8,13 +8,13 @@ class FeedViewController: MicropostViewController {
     // MARK: - View Events
     override func viewDidLoad() {
         super.viewDidLoad()
-        request()
+        request(size: 30)
 
         // Add infinite scroll handler
         tableView.addInfiniteScrollWithHandler { (scrollView) -> Void in
             let tableView = scrollView as! UITableView
-            if (self.microposts.nextPage != nil) {
-                self.request(page: self.microposts.nextPage!)
+            if (self.microposts.lowerId() != nil) {
+                self.request(upperId: self.microposts.lowerId())
             }
             tableView.finishInfiniteScroll()
         }
@@ -29,11 +29,20 @@ class FeedViewController: MicropostViewController {
             self.addData(data, refreshControl: self.refreshControl!)
         }
     }
-    
-    func request(page: Int = 1) {
-        let params = [
-            "page": String(page)
-        ]
+
+    func request(upperId: Int? = nil, lowerId: Int? = nil, size: Int? = nil) {
+        var params = Dictionary<String, AnyObject>()
+
+        if let upper = upperId {
+            params["upper"] = String(upper)
+        }
+        if let lower = lowerId {
+            params["lower"] = String(lower)
+        }
+        if let s = size {
+            params["size"] = String(s)
+        }
+
         Alamofire.request(Router.GetFeed(params: params)).responseJSON { (request, response, data, error) -> Void in
             self.setData(data)
             self.addInfiniteScroll()
@@ -44,7 +53,7 @@ class FeedViewController: MicropostViewController {
         tableView.addInfiniteScrollWithHandler { (scrollView) -> Void in
             let tableView = scrollView as! UITableView
             if (self.microposts.nextPage != nil) {
-                self.request(page: self.microposts.nextPage!)
+                self.request(upperId: self.microposts.lowerId())
             }
             tableView.finishInfiniteScroll()
         }

--- a/Kakico/Classes/Models/Router.swift
+++ b/Kakico/Classes/Models/Router.swift
@@ -2,8 +2,7 @@ import Alamofire
 import KeychainAccess
 
 enum Router: URLRequestConvertible {
-//    static let baseURLString = "https://157.7.190.148"
-    static let baseURLString = "http://localhost:3000"
+    static let baseURLString = "https://157.7.190.148"
 
     case GetUser(userId: Int)
 

--- a/Kakico/Classes/Models/Router.swift
+++ b/Kakico/Classes/Models/Router.swift
@@ -2,7 +2,8 @@ import Alamofire
 import KeychainAccess
 
 enum Router: URLRequestConvertible {
-    static let baseURLString = "https://157.7.190.148"
+//    static let baseURLString = "https://157.7.190.148"
+    static let baseURLString = "http://localhost:3000"
 
     case GetUser(userId: Int)
 
@@ -52,7 +53,7 @@ enum Router: URLRequestConvertible {
         switch self {
         case .GetUser(let userId): return "/api/users/\(userId)"
 
-        case .GetFeed(let page): return "/api/users/feed"
+        case .GetFeed: return "/api/users/feed"
         case .GetAllUsers: return "/api/users"
 
         case GetLatestFeed(let lastUpdate): return "/api/users/feed/latest/\(lastUpdate)"


### PR DESCRIPTION
@orzup @alotofwe 

新しいFeedAPIは取得範囲をnextPageではなくidの上限下限で指定するので、それに対応します。
新APIはまだデプロイされていないため、確認にはローカルのものを使ってください。
### merge条件
- [x] @orzup or @alotofwe  が動作確認をすること
  - [x] feedにてポストが表示されること
  - [x] 下までスクロールしたときに、さらに古いポストが取得されること
