### PR TITLE
Feedでセルをタップするとプロフィール画面へ遷移するように変更

### DIFF
--- a/Kakico.xcodeproj/project.pbxproj
+++ b/Kakico.xcodeproj/project.pbxproj
@@ -43,8 +43,6 @@
 		AB785DE21B848715002DA142 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = AB785DE11B848715002DA142 /* LaunchScreen.xib */; };
 		AB980B101B93FC2300ED6ACB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AB980B0F1B93FC2300ED6ACB /* Main.storyboard */; };
 		ABB01A101BA7C81E004B2486 /* followButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB01A0F1BA7C81E004B2486 /* followButton.swift */; };
-		ABD4E04E1BAAB13F0062290A /* MicropostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 893C220A1B9835EE00C006E4 /* MicropostViewController.swift */; };
-		ABD4E04F1BAAB14A0062290A /* FeedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89878BB11B844E8C004CCD77 /* FeedViewController.swift */; };
 		ABD4E0501BAAB2740062290A /* MicropostCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF1C7301B84557D00032F37 /* MicropostCell.swift */; };
 		ABD4E0521BAAB3050062290A /* delete_micropost.json in Resources */ = {isa = PBXBuildFile; fileRef = ABD4E0511BAAB3050062290A /* delete_micropost.json */; };
 		ABD4E0561BAABCD60062290A /* delete_micropost_404.json in Resources */ = {isa = PBXBuildFile; fileRef = ABD4E0551BAABCD60062290A /* delete_micropost_404.json */; };
@@ -562,10 +560,8 @@
 				6B653F3C1BA67339008BAC59 /* UserTests.swift in Sources */,
 				6BCAE9731BA6ABB300A5C447 /* Router.swift in Sources */,
 				6B8C45191BA67068006195BF /* APIClientTests.swift in Sources */,
-				ABD4E04F1BAAB14A0062290A /* FeedViewController.swift in Sources */,
 				6B82560A1B8AE755005E2397 /* User.swift in Sources */,
 				6B653F3D1BA69174008BAC59 /* APIClient.swift in Sources */,
-				ABD4E04E1BAAB13F0062290A /* MicropostViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Kakico/Classes/Controllers/FeedViewController.swift
+++ b/Kakico/Classes/Controllers/FeedViewController.swift
@@ -23,6 +23,22 @@ class FeedViewController: MicropostViewController {
         resetFeed()
     }
 
+    // MARK: - Actions
+    @IBAction func tapIcon(sender: UITapGestureRecognizer) {
+        let tappedLocation = sender.locationInView(tableView)
+        let tappedPath = tableView.indexPathForRowAtPoint(tappedLocation)
+        let tappedRow = tappedPath?.row
+        showProfileView(microposts[tappedRow!].userId)
+    }
+
+    // MARK: - Navigation
+    private func showProfileView(userId: Int) {
+        let viewController = self.storyboard?.instantiateViewControllerWithIdentifier("ProfileView") as! ProfileViewController
+        viewController._selectUserId = userId
+        showViewController(viewController, sender: nil)
+    }
+
+    // MARK: -
     func resetFeed() {
         let params = [
             "size": self.microposts.size

--- a/Kakico/Classes/Storyboards/Main.storyboard
+++ b/Kakico/Classes/Storyboards/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="1o7-qB-Pic">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="1o7-qB-Pic">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
         <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
@@ -68,8 +68,9 @@
                                                 </mask>
                                             </variation>
                                         </imageView>
-                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="NE1-O0-oeN">
+                                        <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" restorationIdentifier="hoga" translatesAutoresizingMaskIntoConstraints="NO" id="NE1-O0-oeN">
                                             <rect key="frame" x="0.0" y="0.0" width="240" height="128"/>
+                                            <gestureRecognizers/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="50" id="57J-8D-zxc"/>
                                                 <constraint firstAttribute="width" constant="50" id="vWD-XP-wyg"/>
@@ -179,6 +180,7 @@
                             <outlet property="dataSource" destination="Lvb-ZI-qJv" id="4Tu-o5-OFd"/>
                             <outlet property="delegate" destination="Lvb-ZI-qJv" id="CZr-qG-oMR"/>
                             <outletCollection property="gestureRecognizers" destination="1qJ-6S-mYF" appends="YES" id="L7h-qg-Uhn"/>
+                            <outletCollection property="gestureRecognizers" destination="Pol-ei-I4Y" appends="YES" id="B9Z-V9-gD3"/>
                         </connections>
                     </tableView>
                     <navigationItem key="navigationItem" title="Feed" id="Jbw-O7-ucR">
@@ -200,6 +202,11 @@
                         <action selector="longPushed:" destination="Lvb-ZI-qJv" id="hx8-Cr-VoK"/>
                     </connections>
                 </pongPressGestureRecognizer>
+                <tapGestureRecognizer id="Pol-ei-I4Y">
+                    <connections>
+                        <action selector="tapIcon:" destination="Lvb-ZI-qJv" id="lIv-Wg-6Yl"/>
+                    </connections>
+                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="-216" y="-484"/>
         </scene>
@@ -2193,7 +2200,7 @@
         <!--Profile-->
         <scene sceneID="cpi-Lj-QyF">
             <objects>
-                <tableViewController id="Y87-VY-49y" customClass="ProfileViewController" customModule="Kakico" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController storyboardIdentifier="ProfileView" id="Y87-VY-49y" customClass="ProfileViewController" customModule="Kakico" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="Rig-xa-LSt">
                         <rect key="frame" x="0.0" y="0.0" width="400" height="230"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -2390,9 +2397,9 @@
         <image name="hamburger" width="22" height="22"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="eph-rC-yrT"/>
-        <segue reference="t9R-Wy-UH5"/>
         <segue reference="6jz-1V-Yxg"/>
+        <segue reference="t9R-Wy-UH5"/>
+        <segue reference="eph-rC-yrT"/>
     </inferredMetricsTieBreakers>
     <color key="tintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
 </document>


### PR DESCRIPTION
アイコンをタップするとプロフィール画面へ遷移する予定でしたが、
マイクロポスト自体をタップするとプロフィール画面へ遷移するように変えています。
- @alotofwe or @ku00
  - フィードでマイクロポストをタップするとプロフィール画面へ遷移すること
  - プロフィール画面ではマイクロポストをタップしても遷移しないこと
