### PR TITLE
フォローボタンのタップ領域を広げる

### DIFF
--- a/Kakico/Classes/Views/followButton.swift
+++ b/Kakico/Classes/Views/followButton.swift
@@ -32,4 +32,14 @@ class followButton: UIButton {
     func isFollowing() -> Bool {
         return titleLabel!.text == "Follow"
     }
+
+    override func pointInside(point: CGPoint, withEvent event: UIEvent?) -> Bool {
+        var rect: CGRect = self.bounds
+        rect.origin.x -= 10
+        rect.origin.y -= 10
+        rect.size.width += 20
+        rect.size.height += 20
+
+        return CGRectContainsPoint(rect, point)
+    }
 }


### PR DESCRIPTION
@orzup @alotofwe 

ユーザリストからフォローボタンを押すときにタップ判定が厳しいとの指摘が入ったのでちょっと(上下左右10pxずつ)広げます。
# Merge条件
- [x] Passed CI
- [x] 1 LGTM
