### PR TITLE
ユーザリストにて、特定のセルをタップするとアプリが落ちるのを修正

### DIFF
--- a/Kakico/Classes/Controllers/UserViewController.swift
+++ b/Kakico/Classes/Controllers/UserViewController.swift
@@ -17,7 +17,6 @@ class UserViewController: UITableViewController {
         super.viewWillAppear(true)
         resetSeparatorStyle()
         SVProgressHUD.showWithMaskType(.Black)
-        users.drop()
         request(_listType)
         self.refreshControl = UIRefreshControl()
         self.refreshControl!.addTarget(self, action: "refreshUsers", forControlEvents: UIControlEvents.ValueChanged)


### PR DESCRIPTION
@orzup @alotofwe 

自分の実機(5c)では、ロード時の画面に表示されているものより下のものをタップするとアプリがクラッシュして落ちるようになっている。しかし、他の2人には同様のバグが見られなかった。なぜだ...。

修正内容としては、ユーザを格納する変数に生やしている全ユーザを削除するメソッドが無駄に走っていたのを削除した。これで上記の症状は解消された。
# Merge条件
- [x] Passed CI
- [x] 1 LGTM
