### PR TITLE
Pull to Refreshでプロフィールヘッダーも更新する

### DIFF
--- a/Kakico/Classes/Controllers/ProfileViewController.swift
+++ b/Kakico/Classes/Controllers/ProfileViewController.swift
@@ -31,6 +31,9 @@ class ProfileViewController: MicropostViewController {
 
     // MARK: - API request methods
     func refreshProfile() -> Void {
+        var profileHeaderView = self.childViewControllers.first as! ProfileHeaderViewController
+        profileHeaderView.request(_selectUserId)
+
         Alamofire.request(Router.GetLatestMicroposts(userId: self._selectUserId, lastUpdate: self.microposts.lastUpdate())).responseJSON { (request, response, data, error) -> Void in
             self.addData(data, refreshControl: self.refreshControl!)
         }


### PR DESCRIPTION
@orzup @alotofwe 

ポストだけでなくヘッダーも同時に更新できるようにします。
# Merge条件
- @orzup or @alotofwe 
  - Pull to Refreshでヘッダーの情報が更新されること
    - ポスト数が増える、名前が変更されるなど
