### PR TITLE
FeedとProfileでは独自のseparatorを使うように変更

### DIFF
--- a/Kakico/Classes/Controllers/MicropostViewController.swift
+++ b/Kakico/Classes/Controllers/MicropostViewController.swift
@@ -119,7 +119,6 @@ class MicropostViewController: UITableViewController, UITableViewDataSource, UIT
             dispatch_async(dispatch_get_main_queue(), {
                 self.tableView.reloadData()
             })
-            resetSeparatorStyle()
             SVProgressHUD.dismiss()
         }
     }
@@ -143,16 +142,7 @@ class MicropostViewController: UITableViewController, UITableViewDataSource, UIT
             if let refreshControl = self.refreshControl {
                 refreshControl.endRefreshing()
             }
-            resetSeparatorStyle()
             SVProgressHUD.dismiss()
-        }
-    }
-
-    func resetSeparatorStyle() -> Void {
-        if self.microposts.size == 0 {
-            self.tableView.separatorStyle = .None
-        } else {
-            self.tableView.separatorStyle = .SingleLine
         }
     }
 }

--- a/Kakico/Classes/Storyboards/Main.storyboard
+++ b/Kakico/Classes/Storyboards/Main.storyboard
@@ -11,7 +11,7 @@
         <scene sceneID="wRN-C5-hIj">
             <objects>
                 <tableViewController storyboardIdentifier="FeedViewController" id="Lvb-ZI-qJv" customClass="FeedViewController" customModule="Kakico" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="feed" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="172" sectionHeaderHeight="22" sectionFooterHeight="22" id="Bub-0Z-Svk">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="feed" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="172" sectionHeaderHeight="22" sectionFooterHeight="22" id="Bub-0Z-Svk">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -94,9 +94,29 @@
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZSa-k1-GGT" userLabel="Separator">
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                                            <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="1" id="4g1-NS-Yo6">
+                                                    <variation key="heightClass=regular-widthClass=compact" constant="1"/>
+                                                </constraint>
+                                            </constraints>
+                                            <variation key="default">
+                                                <mask key="constraints">
+                                                    <exclude reference="4g1-NS-Yo6"/>
+                                                </mask>
+                                            </variation>
+                                            <variation key="heightClass=regular-widthClass=compact">
+                                                <mask key="constraints">
+                                                    <include reference="4g1-NS-Yo6"/>
+                                                </mask>
+                                            </variation>
+                                        </view>
                                     </subviews>
                                     <constraints>
                                         <constraint firstItem="NwP-ri-1gG" firstAttribute="top" secondItem="NE1-O0-oeN" secondAttribute="top" id="2Da-ul-8KP"/>
+                                        <constraint firstItem="ZSa-k1-GGT" firstAttribute="leading" secondItem="NE1-O0-oeN" secondAttribute="leading" id="2iv-hg-x1z"/>
                                         <constraint firstItem="f2B-Ob-xQm" firstAttribute="top" secondItem="NwP-ri-1gG" secondAttribute="top" id="C1Q-4L-qUB"/>
                                         <constraint firstItem="mGM-8S-zvL" firstAttribute="leading" secondItem="NE1-O0-oeN" secondAttribute="trailing" constant="8" id="Pko-C3-LoQ"/>
                                         <constraint firstItem="f2B-Ob-xQm" firstAttribute="leading" secondItem="NwP-ri-1gG" secondAttribute="trailing" constant="4" id="QSe-ar-fHc"/>
@@ -105,8 +125,10 @@
                                         <constraint firstItem="f2B-Ob-xQm" firstAttribute="height" secondItem="NwP-ri-1gG" secondAttribute="height" id="TtK-yF-WoQ"/>
                                         <constraint firstItem="yzR-f9-U4L" firstAttribute="top" secondItem="mGM-8S-zvL" secondAttribute="bottom" constant="8" id="Uik-dO-iUs"/>
                                         <constraint firstItem="f2B-Ob-xQm" firstAttribute="trailing" secondItem="mGM-8S-zvL" secondAttribute="trailing" id="V8g-8B-wto"/>
+                                        <constraint firstAttribute="trailing" secondItem="ZSa-k1-GGT" secondAttribute="trailing" id="fw8-Ye-vJs"/>
                                         <constraint firstItem="NwP-ri-1gG" firstAttribute="leading" secondItem="NE1-O0-oeN" secondAttribute="trailing" constant="8" id="mhV-p1-6Ub"/>
                                         <constraint firstItem="yzR-f9-U4L" firstAttribute="trailing" secondItem="mGM-8S-zvL" secondAttribute="trailing" id="nvm-J8-uOl"/>
+                                        <constraint firstAttribute="bottom" secondItem="ZSa-k1-GGT" secondAttribute="bottom" constant="0.5" id="oUH-4R-5ow"/>
                                         <constraint firstAttribute="bottom" secondItem="yzR-f9-U4L" secondAttribute="bottom" constant="8" id="tiB-iv-Ukg"/>
                                         <constraint firstItem="NE1-O0-oeN" firstAttribute="top" secondItem="Ywk-YM-BeB" secondAttribute="topMargin" id="wJ5-MD-szh"/>
                                         <constraint firstAttribute="trailingMargin" secondItem="mGM-8S-zvL" secondAttribute="trailing" id="wg9-Y1-bpt"/>
@@ -119,23 +141,27 @@
                                             <exclude reference="yzR-f9-U4L"/>
                                             <exclude reference="NE1-O0-oeN"/>
                                             <exclude reference="mGM-8S-zvL"/>
+                                            <exclude reference="ZSa-k1-GGT"/>
                                         </mask>
                                         <mask key="constraints">
+                                            <exclude reference="TLc-a3-dmx"/>
+                                            <exclude reference="wJ5-MD-szh"/>
                                             <exclude reference="2Da-ul-8KP"/>
                                             <exclude reference="mhV-p1-6Ub"/>
-                                            <exclude reference="C1Q-4L-qUB"/>
-                                            <exclude reference="QSe-ar-fHc"/>
-                                            <exclude reference="TtK-yF-WoQ"/>
-                                            <exclude reference="V8g-8B-wto"/>
                                             <exclude reference="Pko-C3-LoQ"/>
                                             <exclude reference="SSS-7a-uU7"/>
                                             <exclude reference="wg9-Y1-bpt"/>
-                                            <exclude reference="TLc-a3-dmx"/>
-                                            <exclude reference="wJ5-MD-szh"/>
                                             <exclude reference="Uik-dO-iUs"/>
                                             <exclude reference="nvm-J8-uOl"/>
                                             <exclude reference="tiB-iv-Ukg"/>
                                             <exclude reference="z2e-Ub-ACK"/>
+                                            <exclude reference="2iv-hg-x1z"/>
+                                            <exclude reference="fw8-Ye-vJs"/>
+                                            <exclude reference="oUH-4R-5ow"/>
+                                            <exclude reference="C1Q-4L-qUB"/>
+                                            <exclude reference="QSe-ar-fHc"/>
+                                            <exclude reference="TtK-yF-WoQ"/>
+                                            <exclude reference="V8g-8B-wto"/>
                                         </mask>
                                     </variation>
                                     <variation key="widthClass=compact">
@@ -147,21 +173,31 @@
                                             <include reference="mGM-8S-zvL"/>
                                         </mask>
                                         <mask key="constraints">
+                                            <include reference="TLc-a3-dmx"/>
+                                            <include reference="wJ5-MD-szh"/>
                                             <include reference="2Da-ul-8KP"/>
                                             <include reference="mhV-p1-6Ub"/>
-                                            <include reference="C1Q-4L-qUB"/>
-                                            <include reference="QSe-ar-fHc"/>
-                                            <include reference="TtK-yF-WoQ"/>
-                                            <include reference="V8g-8B-wto"/>
                                             <include reference="Pko-C3-LoQ"/>
                                             <include reference="SSS-7a-uU7"/>
                                             <include reference="wg9-Y1-bpt"/>
-                                            <include reference="TLc-a3-dmx"/>
-                                            <include reference="wJ5-MD-szh"/>
                                             <include reference="Uik-dO-iUs"/>
                                             <include reference="nvm-J8-uOl"/>
                                             <include reference="tiB-iv-Ukg"/>
                                             <include reference="z2e-Ub-ACK"/>
+                                            <include reference="C1Q-4L-qUB"/>
+                                            <include reference="QSe-ar-fHc"/>
+                                            <include reference="TtK-yF-WoQ"/>
+                                            <include reference="V8g-8B-wto"/>
+                                        </mask>
+                                    </variation>
+                                    <variation key="heightClass=regular-widthClass=compact">
+                                        <mask key="subviews">
+                                            <include reference="ZSa-k1-GGT"/>
+                                        </mask>
+                                        <mask key="constraints">
+                                            <include reference="2iv-hg-x1z"/>
+                                            <include reference="fw8-Ye-vJs"/>
+                                            <include reference="oUH-4R-5ow"/>
                                         </mask>
                                     </variation>
                                 </tableViewCellContentView>
@@ -2118,7 +2154,7 @@
         <scene sceneID="cpi-Lj-QyF">
             <objects>
                 <tableViewController storyboardIdentifier="ProfileView" id="Y87-VY-49y" customClass="ProfileViewController" customModule="Kakico" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="Rig-xa-LSt">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="Rig-xa-LSt">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -2181,6 +2217,9 @@
                                                     <include reference="eIz-4y-p11"/>
                                                 </mask>
                                             </variation>
+                                            <variation key="heightClass=regular-widthClass=compact" misplaced="YES">
+                                                <rect key="frame" x="66" y="57" width="326" height="150"/>
+                                            </variation>
                                         </imageView>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="0jk-Wi-AOg">
                                             <rect key="frame" x="0.0" y="0.0" width="240" height="128"/>
@@ -2206,18 +2245,45 @@
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
+                                            <variation key="heightClass=regular-widthClass=compact" misplaced="YES">
+                                                <rect key="frame" x="66" y="33" width="326" height="16.5"/>
+                                            </variation>
                                         </label>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="q13-SY-v8p" userLabel="Separator">
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                                            <color key="backgroundColor" red="0.93725490196078431" green="0.93725490196078431" blue="0.95686274509803926" alpha="1" colorSpace="calibratedRGB"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="1" id="prn-oR-547">
+                                                    <variation key="heightClass=regular-widthClass=compact" constant="1"/>
+                                                </constraint>
+                                            </constraints>
+                                            <variation key="default">
+                                                <mask key="constraints">
+                                                    <exclude reference="prn-oR-547"/>
+                                                </mask>
+                                            </variation>
+                                            <variation key="heightClass=regular-widthClass=compact">
+                                                <mask key="constraints">
+                                                    <include reference="prn-oR-547"/>
+                                                </mask>
+                                            </variation>
+                                        </view>
                                     </subviews>
                                     <constraints>
                                         <constraint firstItem="RQP-PB-hzh" firstAttribute="trailing" secondItem="1tM-c4-Lze" secondAttribute="trailing" id="0tu-Ep-TQO"/>
+                                        <constraint firstAttribute="bottom" secondItem="q13-SY-v8p" secondAttribute="bottom" constant="1.5" id="1Fo-ca-miL">
+                                            <variation key="heightClass=regular-widthClass=compact" constant="0.0"/>
+                                        </constraint>
                                         <constraint firstItem="1tM-c4-Lze" firstAttribute="top" secondItem="S24-WD-RCM" secondAttribute="bottom" constant="8" id="9MI-fO-bel"/>
                                         <constraint firstItem="RQP-PB-hzh" firstAttribute="leading" secondItem="1tM-c4-Lze" secondAttribute="leading" id="Cg9-84-tgW"/>
                                         <constraint firstItem="0jk-Wi-AOg" firstAttribute="leading" secondItem="GQp-2H-oAK" secondAttribute="leadingMargin" id="GUp-aQ-fRm"/>
                                         <constraint firstItem="S24-WD-RCM" firstAttribute="leading" secondItem="gYp-cr-wRb" secondAttribute="trailing" constant="4" id="LpU-6y-p5Q"/>
+                                        <constraint firstAttribute="trailing" secondItem="q13-SY-v8p" secondAttribute="trailing" id="Qac-w6-e6r"/>
                                         <constraint firstItem="S24-WD-RCM" firstAttribute="top" secondItem="gYp-cr-wRb" secondAttribute="top" id="V6n-pF-dWJ"/>
                                         <constraint firstItem="gYp-cr-wRb" firstAttribute="leading" secondItem="0jk-Wi-AOg" secondAttribute="trailing" constant="8" id="an9-e2-77u"/>
                                         <constraint firstItem="S24-WD-RCM" firstAttribute="trailing" secondItem="1tM-c4-Lze" secondAttribute="trailing" id="f2h-Xz-j0l"/>
                                         <constraint firstItem="RQP-PB-hzh" firstAttribute="top" secondItem="1tM-c4-Lze" secondAttribute="bottom" constant="8" id="jmc-mG-QX5"/>
+                                        <constraint firstItem="0jk-Wi-AOg" firstAttribute="leading" secondItem="q13-SY-v8p" secondAttribute="leading" id="lLP-HM-nu7"/>
                                         <constraint firstAttribute="trailingMargin" secondItem="1tM-c4-Lze" secondAttribute="trailing" id="lcn-LD-Fs0"/>
                                         <constraint firstAttribute="bottom" secondItem="RQP-PB-hzh" secondAttribute="bottom" constant="8" id="pHd-OR-Fj9"/>
                                         <constraint firstItem="1tM-c4-Lze" firstAttribute="leading" secondItem="0jk-Wi-AOg" secondAttribute="trailing" constant="8" id="pTp-YU-eYD"/>
@@ -2232,23 +2298,27 @@
                                             <exclude reference="RQP-PB-hzh"/>
                                             <exclude reference="0jk-Wi-AOg"/>
                                             <exclude reference="1tM-c4-Lze"/>
+                                            <exclude reference="q13-SY-v8p"/>
                                         </mask>
                                         <mask key="constraints">
+                                            <exclude reference="GUp-aQ-fRm"/>
+                                            <exclude reference="lLP-HM-nu7"/>
+                                            <exclude reference="xgj-Pb-N8p"/>
+                                            <exclude reference="an9-e2-77u"/>
+                                            <exclude reference="xPP-51-ins"/>
                                             <exclude reference="9MI-fO-bel"/>
                                             <exclude reference="lcn-LD-Fs0"/>
                                             <exclude reference="pTp-YU-eYD"/>
-                                            <exclude reference="LpU-6y-p5Q"/>
-                                            <exclude reference="V6n-pF-dWJ"/>
-                                            <exclude reference="f2h-Xz-j0l"/>
-                                            <exclude reference="uCv-Bq-jxe"/>
-                                            <exclude reference="an9-e2-77u"/>
-                                            <exclude reference="xPP-51-ins"/>
-                                            <exclude reference="GUp-aQ-fRm"/>
-                                            <exclude reference="xgj-Pb-N8p"/>
                                             <exclude reference="0tu-Ep-TQO"/>
                                             <exclude reference="Cg9-84-tgW"/>
                                             <exclude reference="jmc-mG-QX5"/>
                                             <exclude reference="pHd-OR-Fj9"/>
+                                            <exclude reference="1Fo-ca-miL"/>
+                                            <exclude reference="Qac-w6-e6r"/>
+                                            <exclude reference="LpU-6y-p5Q"/>
+                                            <exclude reference="V6n-pF-dWJ"/>
+                                            <exclude reference="f2h-Xz-j0l"/>
+                                            <exclude reference="uCv-Bq-jxe"/>
                                         </mask>
                                     </variation>
                                     <variation key="widthClass=compact">
@@ -2260,21 +2330,31 @@
                                             <include reference="1tM-c4-Lze"/>
                                         </mask>
                                         <mask key="constraints">
+                                            <include reference="GUp-aQ-fRm"/>
+                                            <include reference="xgj-Pb-N8p"/>
+                                            <include reference="an9-e2-77u"/>
+                                            <include reference="xPP-51-ins"/>
                                             <include reference="9MI-fO-bel"/>
                                             <include reference="lcn-LD-Fs0"/>
                                             <include reference="pTp-YU-eYD"/>
-                                            <include reference="LpU-6y-p5Q"/>
-                                            <include reference="V6n-pF-dWJ"/>
-                                            <include reference="f2h-Xz-j0l"/>
-                                            <include reference="uCv-Bq-jxe"/>
-                                            <include reference="an9-e2-77u"/>
-                                            <include reference="xPP-51-ins"/>
-                                            <include reference="GUp-aQ-fRm"/>
-                                            <include reference="xgj-Pb-N8p"/>
                                             <include reference="0tu-Ep-TQO"/>
                                             <include reference="Cg9-84-tgW"/>
                                             <include reference="jmc-mG-QX5"/>
                                             <include reference="pHd-OR-Fj9"/>
+                                            <include reference="LpU-6y-p5Q"/>
+                                            <include reference="V6n-pF-dWJ"/>
+                                            <include reference="f2h-Xz-j0l"/>
+                                            <include reference="uCv-Bq-jxe"/>
+                                        </mask>
+                                    </variation>
+                                    <variation key="heightClass=regular-widthClass=compact">
+                                        <mask key="subviews">
+                                            <include reference="q13-SY-v8p"/>
+                                        </mask>
+                                        <mask key="constraints">
+                                            <include reference="lLP-HM-nu7"/>
+                                            <include reference="1Fo-ca-miL"/>
+                                            <include reference="Qac-w6-e6r"/>
                                         </mask>
                                     </variation>
                                 </tableViewCellContentView>
@@ -2369,7 +2449,7 @@
                     </connections>
                 </pongPressGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="631.5" y="1019"/>
+            <point key="canvasLocation" x="631.5" y="1018.5"/>
         </scene>
     </scenes>
     <resources>


### PR DESCRIPTION
cellに灰色で細長いUIViewをのせて、擬似separatorに変更しました。
- @ku00 or @alotofwe
  - feedにseparatorが表示されていること
  - profileにseparatorが表示されていること
    - 一番最古の、涅槃アイコンの下にseparatorが表示されていないこと
